### PR TITLE
Add sshd feature and SSH support to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,13 +28,13 @@
 			]
 		}
 	},
-
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"remoteEnv": {
 		"PATH": "${containerEnv:PATH}:/home/vscode/.nsccli/bin"
 	},
 	"features": {
+		"ghcr.io/devcontainers/features/sshd:1": {},
 		"git": "latest"
 	}
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -16,10 +16,17 @@ services:
         VARIANT: 1.19-bullseye
         NODE_VERSION: "none"
     command: sleep infinity
+# uncomment along with bind volume to use SSH for dev container access
+#    ports:
+#      - "127.0.0.1:2224:2222"
     env_file:
       - .env
     volumes:
       - ..:/workspace:cached
+#      - type: bind
+#        source: ~/.ssh/authorized_keys
+#        target: /home/vscode/.ssh/authorized_keys
+#        read_only: true
     networks:
       - infradev
     # Use "forwardPorts" in **devcontainer.json** to forward a port locally.


### PR DESCRIPTION
This PR adds the `sshd` feature to the permissions-api dev container, allowing users to access it through SSH rather than `docker exec` or similar tools.