### PR TITLE
Rename permission check in internal API for readability

### DIFF
--- a/internal/api/permissions.go
+++ b/internal/api/permissions.go
@@ -33,7 +33,7 @@ func (r *Router) checkScope(c *gin.Context) {
 		return
 	}
 
-	err = query.ActorHasPermission(ctx, r.authzedClient, actorResource, scope, resource, "")
+	err = query.SubjectHasPermission(ctx, r.authzedClient, actorResource, scope, resource, "")
 	if err != nil {
 		if errors.Is(err, query.ErrScopeNotAssigned) {
 			c.JSON(http.StatusForbidden, gin.H{"message": "actor does not have requested scope"})

--- a/internal/query/tenants.go
+++ b/internal/query/tenants.go
@@ -18,12 +18,16 @@ var (
 	BuiltInRoleViewers = "Viewers"
 )
 
-func ActorHasPermission(ctx context.Context, db *authzed.Client, actor *Resource, scope string, object *Resource, queryToken string) error {
+// SubjectHasPermission checks if a given subject is allowed to execute
+// an action on a given resource. Given that permissions evaluate on targets
+// that is object + action, we need to pass in the target as a string.
+// The resource is the tenant that the target is being executed on.
+func SubjectHasPermission(ctx context.Context, db *authzed.Client, subject *Resource, target string, resource *Resource, queryToken string) error {
 	req := &pb.CheckPermissionRequest{
-		Resource:   object.spiceDBObjectReference(),
-		Permission: scope,
+		Resource:   resource.spiceDBObjectReference(),
+		Permission: target,
 		Subject: &pb.SubjectReference{
-			Object: actor.spiceDBObjectReference(),
+			Object: subject.spiceDBObjectReference(),
 		},
 	}
 

--- a/internal/query/tenants_test.go
+++ b/internal/query/tenants_test.go
@@ -80,7 +80,7 @@ func TestActorScopes(t *testing.T) {
 	})
 
 	t.Run("check that the user has edit access to an ou", func(t *testing.T) {
-		err := query.ActorHasPermission(ctx, s.SpiceDB, userRes, "loadbalancer_get", tenRes, queryToken)
+		err := query.SubjectHasPermission(ctx, s.SpiceDB, userRes, "loadbalancer_get", tenRes, queryToken)
 		assert.NoError(t, err)
 	})
 
@@ -88,7 +88,7 @@ func TestActorScopes(t *testing.T) {
 		otherUserRes, err := query.NewResourceFromURN("urn:infratographer:subject:" + uuid.NewString())
 		require.NoError(t, err)
 
-		err = query.ActorHasPermission(ctx, s.SpiceDB, otherUserRes, "loadbalancer_get", tenRes, queryToken)
+		err = query.SubjectHasPermission(ctx, s.SpiceDB, otherUserRes, "loadbalancer_get", tenRes, queryToken)
 		assert.Error(t, err)
 		assert.ErrorIs(t, err, query.ErrScopeNotAssigned)
 	})


### PR DESCRIPTION
The idea is to better document and reflect the concepts permissions-api
introduces.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
