### PR TITLE
Simplify schema to only be subjects, roles and tenants

### DIFF
--- a/internal/query/tenants.go
+++ b/internal/query/tenants.go
@@ -205,20 +205,6 @@ func GetResourceTypes() []*ResourceType {
 			DBType:    "subject",
 			URNPrefix: "urn:infratographer:subject",
 		},
-		{
-			Name:      "Load balancer",
-			DBType:    "loadbalancer",
-			URNPrefix: "urn:infratographer:loadbalancer",
-			Relationships: []*ResourceRelationship{
-				{
-					Name:       "Tenant",
-					Field:      "tenant_id",
-					DBTypes:    "tenant",
-					DBRelation: "tenant",
-					Optional:   false,
-				},
-			},
-		},
 	}
 }
 

--- a/internal/query/tenants_test.go
+++ b/internal/query/tenants_test.go
@@ -51,7 +51,7 @@ func dbTest(ctx context.Context, t *testing.T) *query.Stores {
 }
 
 func cleanDB(ctx context.Context, t *testing.T, client *authzed.Client) {
-	for _, dbType := range []string{"subject", "role", "tenant", "loadbalancer"} {
+	for _, dbType := range []string{"subject", "role", "tenant"} {
 		delRequest := &pb.DeleteRelationshipsRequest{RelationshipFilter: &pb.RelationshipFilter{ResourceType: dbType}}
 		_, err := client.DeleteRelationships(ctx, delRequest)
 		require.NoError(t, err, "failure deleting relationships")

--- a/internal/spicedbx/schema.go
+++ b/internal/spicedbx/schema.go
@@ -28,18 +28,6 @@ definition PREFIX/tenant {
     permission loadbalancer_update = loadbalancer_update_rel + parent->loadbalancer_update
     permission loadbalancer_delete = loadbalancer_delete_rel + parent->loadbalancer_delete
 }
-
-definition PREFIX/loadbalancer {
-    relation tenant: PREFIX/tenant
-
-    relation loadbalancer_get_rel: PREFIX/role#subject
-    relation loadbalancer_update_rel: PREFIX/role#subject
-    relation loadbalancer_delete_rel: PREFIX/role#subject
-
-    permission loadbalancer_get = loadbalancer_get_rel + tenant->loadbalancer_get
-    permission loadbalancer_update = loadbalancer_update_rel + tenant->loadbalancer_update
-    permission loadbalancer_delete = loadbalancer_delete_rel + tenant->loadbalancer_delete
-}
 `
 
 	if prefix != "" && !strings.HasSuffix(prefix, "/") {


### PR DESCRIPTION
To make it easier to reason around what exactly is needed for authorization, and reduce the implicit coupling of services for getting resource information, this PR removes load balancers as a resource type in permissions-api.