### PR TITLE
Authenticate API requests

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -95,3 +95,24 @@ services:
   jaeger:
     image: jaegertracing/all-in-one:1.43.0
     network_mode: service:app
+
+  mock-oauth2-server:
+    image: ghcr.io/navikt/mock-oauth2-server:0.5.8
+    networks:
+      - infradev
+    environment:
+      - PORT=8081
+    ports:
+      - 8081:8081
+
+  mock-oauth2-server-health:
+    image: alpine:3.17
+    networks:
+      - infradev
+    command: ["sleep", "infinity"]
+    healthcheck:
+      test: ["CMD", "wget", "-O", "-", "http:/mock-oauth2-server:8081/.well-known/openid-configuration"]
+      interval: 5s
+      timeout: 10s
+      retries: 20
+      start_period: 5s

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -104,15 +104,3 @@ services:
       - PORT=8081
     ports:
       - 8081:8081
-
-  mock-oauth2-server-health:
-    image: alpine:3.17
-    networks:
-      - infradev
-    command: ["sleep", "infinity"]
-    healthcheck:
-      test: ["CMD", "wget", "-O", "-", "http:/mock-oauth2-server:8081/.well-known/openid-configuration"]
-      interval: 5s
-      timeout: 10s
-      retries: 20
-      start_period: 5s

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
+	go.hollow.sh/toolbox v0.5.1
 	go.infratographer.com/x v0.0.3
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.40.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0
@@ -77,7 +78,6 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.9 // indirect
 	github.com/zsais/go-gin-prometheus v0.1.0 // indirect
-	go.hollow.sh/toolbox v0.5.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.37.0 // indirect
 	go.opentelemetry.io/otel/exporters/jaeger v1.11.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.9 // indirect
 	github.com/zsais/go-gin-prometheus v0.1.0 // indirect
+	go.hollow.sh/toolbox v0.5.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.37.0 // indirect
 	go.opentelemetry.io/otel/exporters/jaeger v1.11.2 // indirect
@@ -101,5 +102,6 @@ require (
 	google.golang.org/genproto v0.0.0-20230209215440-0dfe4f8abfcc // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1869,6 +1869,8 @@ go.etcd.io/etcd/client/v3 v3.5.4/go.mod h1:ZaRkVgBZC+L+dLCjTcF1hRXpgZXQPOvnA/Ak/
 go.etcd.io/etcd/pkg/v3 v3.5.0/go.mod h1:UzJGatBQ1lXChBkQF0AuAtkRQMYnHubxAEYIrC3MSsE=
 go.etcd.io/etcd/raft/v3 v3.5.0/go.mod h1:UFOHSIvO/nKwd4lhkwabrTD3cqW5yVyYYf/KlD00Szc=
 go.etcd.io/etcd/server/v3 v3.5.0/go.mod h1:3Ah5ruV+M+7RZr0+Y/5mNLwC+eQlni+mQmOVdCRJoS4=
+go.hollow.sh/toolbox v0.5.1 h1:x/tRdpgUFckT/pw6FySxUpSFxhw+Sc66zxbwlra+br4=
+go.hollow.sh/toolbox v0.5.1/go.mod h1:nfUNHobFfItossU5I0m7h2dw+0nY7rQt3DSUm2wGI5Q=
 go.infratographer.com/x v0.0.3 h1:7txN1iBq1Ts4XF6Ea/9/LWK2vpTeXKnh+DjdJ1OLHVQ=
 go.infratographer.com/x v0.0.3/go.mod h1:6qJTwrxN8O3X0v/v2/O7pZkq1T8V7rNDSnzZKJeEmRQ=
 go.mongodb.org/mongo-driver v1.7.3/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R79oO62zWg=
@@ -2826,6 +2828,8 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.3.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
+gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/telebot.v3 v3.0.0/go.mod h1:7rExV8/0mDDNu9epSrDm/8j22KLaActH1Tbee6YjzWg=
 gopkg.in/telebot.v3 v3.1.2/go.mod h1:GJKwwWqp9nSkIVN51eRKU78aB5f5OnQuWdwiIZfPbko=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1,0 +1,15 @@
+package api
+
+import (
+	"github.com/gin-gonic/gin"
+	"go.hollow.sh/toolbox/ginjwt"
+)
+
+func newAuthMiddleware(cfg ginjwt.AuthConfig) (func(*gin.Context), error) {
+	mw, err := ginjwt.NewMultiTokenMiddlewareFromConfigs(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return mw.AuthRequired(nil), nil
+}

--- a/internal/api/permissions.go
+++ b/internal/api/permissions.go
@@ -6,14 +6,21 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"go.infratographer.com/permissions-api/internal/query"
+	"go.infratographer.com/x/urnx"
 )
 
 func (r *Router) checkScope(c *gin.Context) {
-	resourceURN := c.Param("urn")
+	resourceURNStr := c.Param("urn")
 	scope := c.Param("scope")
 
 	ctx, span := tracer.Start(c.Request.Context(), "api.checkScope")
 	defer span.End()
+
+	resourceURN, err := urnx.Parse(resourceURNStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"message": "error processing resource URN", "error": err.Error()})
+		return
+	}
 
 	resource, err := query.NewResourceFromURN(resourceURN)
 	if err != nil {
@@ -27,7 +34,7 @@ func (r *Router) checkScope(c *gin.Context) {
 		return
 	}
 
-	actorResource, err := query.NewResourceFromURN(actor.String())
+	actorResource, err := query.NewResourceFromURN(actor)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"message": "error processing actor URN", "error": err.Error()})
 		return

--- a/internal/api/permissions.go
+++ b/internal/api/permissions.go
@@ -27,7 +27,7 @@ func (r *Router) checkScope(c *gin.Context) {
 		return
 	}
 
-	actorResource, err := query.NewResourceFromURN(actor.urn)
+	actorResource, err := query.NewResourceFromURN(actor.String())
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"message": "error processing actor URN", "error": err.Error()})
 		return

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -32,7 +32,7 @@ func (r *Router) resourceCreate(c *gin.Context) {
 		return
 	}
 
-	actorResource, err := query.NewResourceFromURN(actor.urn)
+	actorResource, err := query.NewResourceFromURN(actor.String())
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"message": "error processing actor URN", "error": err.Error()})
 		return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"go.hollow.sh/toolbox/ginjwt"
 	"go.infratographer.com/x/ginx"
 	"go.infratographer.com/x/loggingx"
 	"go.infratographer.com/x/otelx"
@@ -9,6 +10,7 @@ import (
 )
 
 type AppConfig struct {
+	OIDC    ginjwt.AuthConfig
 	Logging loggingx.Config
 	Server  ginx.Config
 	SpiceDB spicedbx.Config

--- a/internal/query/tenants_test.go
+++ b/internal/query/tenants_test.go
@@ -16,6 +16,7 @@ import (
 
 	"go.infratographer.com/permissions-api/internal/query"
 	"go.infratographer.com/permissions-api/internal/spicedbx"
+	"go.infratographer.com/x/urnx"
 )
 
 func dbTest(ctx context.Context, t *testing.T) *query.Stores {
@@ -64,11 +65,13 @@ func TestActorScopes(t *testing.T) {
 
 	var err error
 
-	tenURN := "urn:infratographer:tenant:" + uuid.NewString()
+	tenURN, err := urnx.Build("infratographer", "tenant", uuid.New())
+	require.NoError(t, err)
 	tenRes, err := query.NewResourceFromURN(tenURN)
 	require.NoError(t, err)
-	userURN := "urn:infratographer:subject:" + uuid.NewString()
-	userRes, err := query.NewResourceFromURN(userURN)
+	subjURN, err := urnx.Build("infratographer", "subject", uuid.New())
+	require.NoError(t, err)
+	userRes, err := query.NewResourceFromURN(subjURN)
 	require.NoError(t, err)
 
 	queryToken, err := query.CreateBuiltInRoles(ctx, s.SpiceDB, tenRes)
@@ -85,7 +88,9 @@ func TestActorScopes(t *testing.T) {
 	})
 
 	t.Run("error returned when the user doesn't have the global scope", func(t *testing.T) {
-		otherUserRes, err := query.NewResourceFromURN("urn:infratographer:subject:" + uuid.NewString())
+		subjURN, err := urnx.Build("infratographer", "subject", uuid.New())
+		require.NoError(t, err)
+		otherUserRes, err := query.NewResourceFromURN(subjURN)
 		require.NoError(t, err)
 
 		err = query.ActorHasPermission(ctx, s.SpiceDB, otherUserRes, "loadbalancer_get", tenRes, queryToken)

--- a/permission-api.example.yaml
+++ b/permission-api.example.yaml
@@ -1,0 +1,4 @@
+oidc:
+  issuer: http://localhost:8081/default
+  audience: permissions-api
+  jwksuri: http://mock-oauth2-server:8081/default/jwks

--- a/pkg/pubsubx/worker.go
+++ b/pkg/pubsubx/worker.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/nats-io/nats.go"
 	"go.infratographer.com/permissions-api/internal/query"
+	"go.infratographer.com/x/urnx"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 	"gocloud.dev/pubsub"
@@ -200,7 +201,13 @@ func (s *Subscription) Receive(ctx context.Context, st *query.Stores) error {
 func (s *Subscription) ProcessMessage(ctx context.Context, db *query.Stores, msg *Message) error {
 	switch {
 	case strings.HasSuffix(msg.EventType, ".added"):
-		resource, err := query.NewResourceFromURN(msg.SubjectURN)
+		subjectURN, err := urnx.Parse(msg.SubjectURN)
+		if err != nil {
+			fmt.Println("Error getting resource from URN for subject")
+			return err
+		}
+
+		resource, err := query.NewResourceFromURN(subjectURN)
 		if err != nil {
 			fmt.Println("Error getting resource from URN for subject")
 			return err
@@ -208,7 +215,13 @@ func (s *Subscription) ProcessMessage(ctx context.Context, db *query.Stores, msg
 
 		resource.Fields = msg.SubjectFields
 
-		actor, err := query.NewResourceFromURN(msg.ActorURN)
+		actorURN, err := urnx.Parse(msg.ActorURN)
+		if err != nil {
+			fmt.Println("Error getting resource from URN for subject")
+			return err
+		}
+
+		actor, err := query.NewResourceFromURN(actorURN)
 		if err != nil {
 			fmt.Println("Error getting resource from URN for actor")
 			return err

--- a/pkg/pubsubx/worker.go
+++ b/pkg/pubsubx/worker.go
@@ -203,13 +203,21 @@ func (s *Subscription) ProcessMessage(ctx context.Context, db *query.Stores, msg
 	case strings.HasSuffix(msg.EventType, ".added"):
 		subjectURN, err := urnx.Parse(msg.SubjectURN)
 		if err != nil {
-			fmt.Println("Error getting resource from URN for subject")
+			s.logger.Errorw(
+				"Error getting resource from URN for subject",
+				"error",
+				err,
+			)
 			return err
 		}
 
 		resource, err := query.NewResourceFromURN(subjectURN)
 		if err != nil {
-			fmt.Println("Error getting resource from URN for subject")
+			s.logger.Errorw(
+				"Error getting resource from URN for subject",
+				"error",
+				err,
+			)
 			return err
 		}
 
@@ -217,13 +225,21 @@ func (s *Subscription) ProcessMessage(ctx context.Context, db *query.Stores, msg
 
 		actorURN, err := urnx.Parse(msg.ActorURN)
 		if err != nil {
-			fmt.Println("Error getting resource from URN for subject")
+			s.logger.Errorw(
+				"Error getting resource from URN for actor",
+				"error",
+				err,
+			)
 			return err
 		}
 
 		actor, err := query.NewResourceFromURN(actorURN)
 		if err != nil {
-			fmt.Println("Error getting resource from URN for actor")
+			s.logger.Errorw(
+				"Error getting resource from URN for actor",
+				"error",
+				err,
+			)
 			return err
 		}
 


### PR DESCRIPTION
The current implementation of authentication in permissions-api expects a URN in the bearer token instead of a JWT. This PR updates permissions-api's API server to use JWT validation from [`ginjwt`][ginjwt] and URN parsing from [`urnx`][urnx] for more robust and secure authentication of clients making API requests.

Additionally, to make local development easier, a [mock-oauth2-server][mock-oauth2-server] service has been added to the Compose file. This service can be used to get JWT access tokens that permissions-api can be configured to accept instead of using an external identity provider or other authorization server.

[ginjwt]: https://pkg.go.dev/go.hollow.sh/toolbox@v0.5.1/ginjwt
[urnx]: https://pkg.go.dev/go.infratographer.com/x@v0.0.3/urnx
[mock-oauth2-server]: https://github.com/navikt/mock-oauth2-server