### PR TITLE
Use scanners option for Trivy, add Trivy to test action

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -43,8 +43,8 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ steps.docker-metadata.outputs.tags }}
-          security-checks: 'vuln,config,secret'
+          image-ref: ghcr.io/infratographer/permissions-api/permissions-api:latest
+          scanners: 'vuln,config,secret'
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
           format: 'table'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,3 +40,44 @@ jobs:
 
       - name: Run go tests
         run: make test
+
+  image-scan:
+    name: image-scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Registry login
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha
+
+      - name: Build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false
+          load: true
+          tags: ${{ steps.metadata.outputs.tags }}
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ steps.metadata.outputs.tags }}
+          scanners: 'vuln,config,secret'
+          ignore-unfixed: true
+          severity: 'HIGH,CRITICAL'
+          format: 'table'


### PR DESCRIPTION
The trivy-action action removed the security-checks option in favor of the scanners option recently. This PR updates the existing image scanning action to use the right option and also adds image scanning to the test action.