### PR TITLE
Use Trivy more effectively

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,19 +7,18 @@ ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 RUN export DEBIAN_FRONTEND=noninteractive \
-    && curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg \
+    && curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | tee /usr/share/keyrings/helm.gpg \
     &&  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn-archive-keyring.gpg \
     && apt-get install apt-transport-https --yes \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list \
-    && apt-get update \
-    && apt-get -y install --no-install-recommends \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list \
+    && apt-get update && apt-get install --yes --no-install-recommends \
         bash-completion \
         helm \
         uuid-runtime
 
 # Install cockroachdb so we have the client
 RUN curl https://binaries.cockroachdb.com/cockroach-v22.1.8.linux-amd64.tgz | tar -xz \
-    && sudo cp -i cockroach-v22.1.8.linux-amd64/cockroach /usr/local/bin/ \
+    && cp -i cockroach-v22.1.8.linux-amd64/cockroach /usr/local/bin/ \
     && rm -rf cockroach-v*
 
 USER vscode

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,7 +11,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     &&  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn-archive-keyring.gpg \
     && apt-get install apt-transport-https --yes \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list \
-    && apt-get update && apt-get install --yes --no-install-recommends \
+    && apt-get update \
+    && apt-get install --yes --no-install-recommends \
         bash-completion \
         helm \
         uuid-runtime

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -24,6 +24,7 @@ jobs:
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
           format: 'table'
+          exit-code: '1'
 
       - name: Registry login
         uses: docker/login-action@v2
@@ -58,6 +59,7 @@ jobs:
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
           format: 'table'
+          exit-code: '1'
 
       - name: Push
         uses: docker/build-push-action@v4

--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           scan-type: 'fs'
           scan-ref: '.'
-          scanners: 'vuln,config,secret'
+          scanners: 'vuln,secret'
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
           format: 'table'
@@ -55,7 +55,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ghcr.io/infratographer/permissions-api:latest
-          scanners: 'vuln,config,secret'
+          scanners: 'vuln,secret'
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
           format: 'table'

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ steps.metadata.outputs.tags }}
-          scanners: 'vuln,config,secret'
+          scanners: 'vuln,secret'
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
           format: 'table'
@@ -60,7 +60,7 @@ jobs:
         with:
           scan-type: 'fs'
           scan-ref: '.'
-          scanners: 'vuln,config,secret'
+          scanners: 'vuln,secret'
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
           format: 'table'

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -45,6 +45,7 @@ jobs:
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
           format: 'table'
+          exit-code: '1'
 
   repo-scan:
     name: repo-scan
@@ -63,3 +64,4 @@ jobs:
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
           format: 'table'
+          exit-code: '1'

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,15 +1,54 @@
-name: Image build
+name: Trivy Scan
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
-  image-build:
+  image-scan:
+    name: image-scan
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Registry login
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: metadata
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha
+
+      - name: Build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false
+          load: true
+          tags: ${{ steps.metadata.outputs.tags }}
+
+      - name: Scan image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ steps.metadata.outputs.tags }}
+          scanners: 'vuln,config,secret'
+          ignore-unfixed: true
+          severity: 'HIGH,CRITICAL'
+          format: 'table'
+
+  repo-scan:
+    name: repo-scan
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -24,44 +63,3 @@ jobs:
           ignore-unfixed: true
           severity: 'HIGH,CRITICAL'
           format: 'table'
-
-      - name: Registry login
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get Docker metadata
-        id: metadata
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}
-          tags: |
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Build
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: false
-          load: true
-          tags: ${{ steps.metadata.outputs.tags }}
-
-      - name: Scan image
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ghcr.io/infratographer/permissions-api:latest
-          scanners: 'vuln,config,secret'
-          ignore-unfixed: true
-          severity: 'HIGH,CRITICAL'
-          format: 'table'
-
-      - name: Push
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,12 +72,3 @@ jobs:
           push: false
           load: true
           tags: ${{ steps.metadata.outputs.tags }}
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ steps.metadata.outputs.tags }}
-          scanners: 'vuln,config,secret'
-          ignore-unfixed: true
-          severity: 'HIGH,CRITICAL'
-          format: 'table'


### PR DESCRIPTION
The current image scanning workflow leads to Trivy scans being run twice because the test action is run on both PRs and pushes to main. To rectify this, a new security action has been added in this PR that only runs on PRs to scan both the permissions-api Git repository and Docker image. Additionally, repo scanning has been added to the image-build action and a typo in the image tag to be scanned has been fixed.