### PR TITLE
Better actions

### DIFF
--- a/internal/query/tenants.go
+++ b/internal/query/tenants.go
@@ -412,6 +412,24 @@ func (e *Engine) ListRoles(ctx context.Context, resource types.Resource, queryTo
 func GetResourceTypes() []types.ResourceType {
 	return []types.ResourceType{
 		{
+			Name: "loadbalancer",
+			Relationships: []types.ResourceTypeRelationship{
+				{
+					Name: "tenant",
+					Type: "tenant",
+				},
+			},
+		},
+		{
+			Name: "role",
+			Relationships: []types.ResourceTypeRelationship{
+				{
+					Name: "tenant",
+					Type: "tenant",
+				},
+			},
+		},
+		{
 			Name: "tenant",
 			Relationships: []types.ResourceTypeRelationship{
 				{

--- a/internal/query/tenants.go
+++ b/internal/query/tenants.go
@@ -333,8 +333,7 @@ func relationshipsToRoles(rels []*pb.Relationship) []types.Role {
 			roleMap[roleID] = &role
 		}
 
-		actions := roleMap[roleID].Actions
-		roleMap[roleID].Actions = append(actions, action)
+		roleMap[roleID].Actions = append(roleMap[roleID].Actions, action)
 	}
 
 	out := make([]types.Role, len(roleIDs))

--- a/internal/spicedbx/schema.go
+++ b/internal/spicedbx/schema.go
@@ -23,6 +23,12 @@ definition {{$namespace}}/tenant {
     relation tenant: {{$namespace}}/tenant
 {{- range .ResourceTypes -}}
 {{$typeName := .Name}}
+{{range .Actions}}
+    relation {{$typeName}}_{{.}}_rel: {{$namespace}}/role#subject
+{{- end}}
+{{range .Actions}}
+    permission {{$typeName}}_{{.}} = {{$typeName}}_{{.}}_rel + tenant->{{$typeName}}_{{.}}
+{{- end}}
 {{range .TenantActions}}
     relation {{$typeName}}_{{.}}_rel: {{$namespace}}/role#subject
 {{- end}}
@@ -35,10 +41,10 @@ definition {{$namespace}}/tenant {
 {{$typeName := .Name}}
 definition {{$namespace}}/{{$typeName}} {
     relation tenant: {{$namespace}}/tenant
-{{range .TenantActions}}
+{{range .Actions}}
     relation {{$typeName}}_{{.}}_rel: {{$namespace}}/role#subject
 {{- end}}
-{{range .TenantActions}}
+{{range .Actions}}
     permission {{$typeName}}_{{.}} = {{$typeName}}_{{.}}_rel + tenant->{{$typeName}}_{{.}}
 {{- end}}
 }
@@ -74,12 +80,14 @@ func GeneratedSchema(namespace string) string {
 	resourceTypes := []types.ResourceType{
 		{
 			Name: "loadbalancer",
-			TenantActions: []string{
-				"create",
+			Actions: []string{
 				"get",
-				"list",
 				"update",
 				"delete",
+			},
+			TenantActions: []string{
+				"create",
+				"list",
 			},
 		},
 	}

--- a/internal/spicedbx/schema.go
+++ b/internal/spicedbx/schema.go
@@ -17,10 +17,43 @@ definition {{$namespace}}/client {}
 definition {{$namespace}}/role {
     relation tenant: {{$namespace}}/tenant
     relation subject: {{$namespace}}/user | {{$namespace}}/client
+
+    relation role_get_rel: {{$namespace}}/role#subject
+    relation role_update_rel: {{$namespace}}/role#subject
+    relation role_delete_rel: {{$namespace}}/role#subject
+
+    permission role_get = role_get_rel + tenant->role_get
+    permission role_update = role_update_rel + tenant->role_update
+    permission role_delete = role_delete_rel + tenant->role_delete
 }
 
 definition {{$namespace}}/tenant {
     relation tenant: {{$namespace}}/tenant
+
+    relation tenant_create_rel: {{$namespace}}/role#subject
+    relation tenant_get_rel: {{$namespace}}/role#subject
+    relation tenant_list_rel: {{$namespace}}/role#subject
+    relation tenant_update_rel: {{$namespace}}/role#subject
+    relation tenant_delete_rel: {{$namespace}}/role#subject
+
+    permission tenant_create = tenant_create_rel + tenant->tenant_create
+    permission tenant_get = tenant_get_rel + tenant->tenant_get
+    permission tenant_list = tenant_list_rel + tenant->tenant_list
+    permission tenant_update = tenant_update_rel + tenant->tenant_update
+    permission tenant_delete = tenant_delete_rel + tenant->tenant_delete
+
+    relation role_create_rel: {{$namespace}}/role#subject
+    relation role_get_rel: {{$namespace}}/role#subject
+    relation role_list_rel: {{$namespace}}/role#subject
+    relation role_update_rel: {{$namespace}}/role#subject
+    relation role_delete_rel: {{$namespace}}/role#subject
+
+    permission role_create = role_create_rel + tenant->role_create
+    permission role_get = role_get_rel + tenant->role_get
+    permission role_list = role_list_rel + tenant->role_list
+    permission role_update = role_update_rel + tenant->role_update
+    permission role_delete = role_delete_rel + tenant->role_delete
+
 {{- range .ResourceTypes -}}
 {{$typeName := .Name}}
 {{range .Actions}}

--- a/internal/spicedbx/schema_test.go
+++ b/internal/spicedbx/schema_test.go
@@ -55,10 +55,42 @@ definition foo/client {}
 definition foo/role {
     relation tenant: foo/tenant
     relation subject: foo/user | foo/client
+
+    relation role_get_rel: foo/role#subject
+    relation role_update_rel: foo/role#subject
+    relation role_delete_rel: foo/role#subject
+
+    permission role_get = role_get_rel + tenant->role_get
+    permission role_update = role_update_rel + tenant->role_update
+    permission role_delete = role_delete_rel + tenant->role_delete
 }
 
 definition foo/tenant {
     relation tenant: foo/tenant
+
+    relation tenant_create_rel: foo/role#subject
+    relation tenant_get_rel: foo/role#subject
+    relation tenant_list_rel: foo/role#subject
+    relation tenant_update_rel: foo/role#subject
+    relation tenant_delete_rel: foo/role#subject
+
+    permission role_create = role_create_rel + tenant->role_create
+    permission role_get = role_get_rel + tenant->role_get
+    permission role_list = role_list_rel + tenant->role_list
+    permission role_update = role_update_rel + tenant->role_update
+    permission role_delete = role_delete_rel + tenant->role_delete
+
+    relation role_create_rel: foo/role#subject
+    relation role_get_rel: foo/role#subject
+    relation role_list_rel: foo/role#subject
+    relation role_update_rel: foo/role#subject
+    relation role_delete_rel: foo/role#subject
+
+    permission role_create = role_create_rel + tenant->role_create
+    permission role_get = role_get_rel + tenant->role_get
+    permission role_list = role_list_rel + tenant->role_list
+    permission role_update = role_update_rel + tenant->role_update
+    permission role_delete = role_delete_rel + tenant->role_delete
 
     relation loadbalancer_get_rel: foo/role#subject
 

--- a/internal/spicedbx/schema_test.go
+++ b/internal/spicedbx/schema_test.go
@@ -74,11 +74,11 @@ definition foo/tenant {
     relation tenant_update_rel: foo/role#subject
     relation tenant_delete_rel: foo/role#subject
 
-    permission role_create = role_create_rel + tenant->role_create
-    permission role_get = role_get_rel + tenant->role_get
-    permission role_list = role_list_rel + tenant->role_list
-    permission role_update = role_update_rel + tenant->role_update
-    permission role_delete = role_delete_rel + tenant->role_delete
+    permission tenant_create = tenant_create_rel + tenant->tenant_create
+    permission tenant_get = tenant_get_rel + tenant->tenant_get
+    permission tenant_list = tenant_list_rel + tenant->tenant_list
+    permission tenant_update = tenant_update_rel + tenant->tenant_update
+    permission tenant_delete = tenant_delete_rel + tenant->tenant_delete
 
     relation role_create_rel: foo/role#subject
     relation role_get_rel: foo/role#subject

--- a/internal/spicedbx/schema_test.go
+++ b/internal/spicedbx/schema_test.go
@@ -30,16 +30,20 @@ func TestSchema(t *testing.T) {
 	resourceTypes := []types.ResourceType{
 		{
 			Name: "loadbalancer",
+			Actions: []string{
+				"get",
+			},
 			TenantActions: []string{
 				"create",
-				"get",
 			},
 		},
 		{
 			Name: "port",
+			Actions: []string{
+				"get",
+			},
 			TenantActions: []string{
 				"create",
-				"get",
 			},
 		},
 	}
@@ -56,36 +60,36 @@ definition foo/role {
 definition foo/tenant {
     relation tenant: foo/tenant
 
-    relation loadbalancer_create_rel: foo/role#subject
     relation loadbalancer_get_rel: foo/role#subject
 
-    permission loadbalancer_create = loadbalancer_create_rel + tenant->loadbalancer_create
     permission loadbalancer_get = loadbalancer_get_rel + tenant->loadbalancer_get
 
-    relation port_create_rel: foo/role#subject
+    relation loadbalancer_create_rel: foo/role#subject
+
+    permission loadbalancer_create = loadbalancer_create_rel + tenant->loadbalancer_create
+
     relation port_get_rel: foo/role#subject
 
-    permission port_create = port_create_rel + tenant->port_create
     permission port_get = port_get_rel + tenant->port_get
+
+    relation port_create_rel: foo/role#subject
+
+    permission port_create = port_create_rel + tenant->port_create
 }
 
 definition foo/loadbalancer {
     relation tenant: foo/tenant
 
-    relation loadbalancer_create_rel: foo/role#subject
     relation loadbalancer_get_rel: foo/role#subject
 
-    permission loadbalancer_create = loadbalancer_create_rel + tenant->loadbalancer_create
     permission loadbalancer_get = loadbalancer_get_rel + tenant->loadbalancer_get
 }
 
 definition foo/port {
     relation tenant: foo/tenant
 
-    relation port_create_rel: foo/role#subject
     relation port_get_rel: foo/role#subject
 
-    permission port_create = port_create_rel + tenant->port_create
     permission port_get = port_get_rel + tenant->port_get
 }
 `

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -19,6 +19,9 @@ type ResourceTypeRelationship struct {
 type ResourceType struct {
 	Name          string
 	Relationships []ResourceTypeRelationship
+	// Actions represents actions that can be taken on the resource directly
+	Actions []string
+	// TenantActions represents actions that can be taken on the resource's tenant context
 	TenantActions []string
 }
 


### PR DESCRIPTION
permissions-api does not currently define actions on roles or tenants, such as `tenant_get` or `role_list`, or distinguish between actions on a resource and actions on its tenant context. This PR addresses these issues by:

* Adding hardcoded actions for tenants and roles
* Adding `Actions` as an additional field on `ResourceType`, allowing for distinguishing between actions like "get" and "list"

Additionally, this PR fixes a bug when listing resource roles.