### PR TITLE
Add NATS consumer for resource lifecycle events

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -26,6 +26,18 @@ PERMISSIONSAPI_SPICEDB_ENDPOINT=spicedb:50051
 PERMISSIONSAPI_SPICEDB_KEY=$SPICEDB_GRPC_PRESHARED_KEY
 PERMISSIONSAPI_SPICEDB_INSECURE=true
 
+PERMISSIONSAPI_PUBSUB_NAME=permissionsapi
+PERMISSIONSAPI_PUBSUB_CREDENTIALS="/tmp/user.creds"
+PERMISSIONSAPI_PUBSUB_SERVER="nats://nats:4222"
+PERMISSIONSAPI_PUBSUB_STREAM="permissionsapi"
+PERMISSIONSAPI_PUBSUB_PREFIX="com.infratographer.events"
+
 # cockroachdb container config
 COCKROACH_INSECURE=true
 COCKROACH_HOST=crdb:26257
+
+NATS_URL="nats://nats:4222"
+NATS_CREDS="/tmp/user.creds"
+
+NKEYS_PATH="/workspace/.devcontainer/nsc/nkeys"
+NSC_HOME="/workspace/.devcontainer/nsc/nats"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,15 +23,9 @@ RUN curl https://binaries.cockroachdb.com/cockroach-v22.1.8.linux-amd64.tgz | ta
 
 USER vscode
 
-# Add ~/.ssh for the vscode user so updating known_hosts works
-RUN mkdir --mode=700 /home/vscode/.ssh
+# Add ~/.ssh for the vscode user so updating known_hosts works and
+# add .devcontainer/.tools to PATH
+RUN mkdir --mode=700 /home/vscode/.ssh && \
+    echo 'export PATH="${PATH}:/workspace/.tools"' >> ~/.bashrc
 
 WORKDIR /workspace
-
-# [Optional] Uncomment the next lines to use go get to install anything else you need
-# USER vscode
-# RUN go get -x <your-dependency-or-tool>
-# USER root
-
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,7 +34,6 @@
 		"PATH": "${containerEnv:PATH}:/home/vscode/.nsccli/bin"
 	},
 	"features": {
-		"ghcr.io/devcontainers/features/sshd:1": {},
-		"git": "latest"
+		"ghcr.io/devcontainers/features/sshd:1": {}
 	}
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -22,6 +22,8 @@ services:
     env_file:
       - .env
     volumes:
+      - ./nsc:/nsc
+      - ./nats:/nats
       - ..:/workspace:cached
 #      - type: bind
 #        source: ~/.ssh/authorized_keys
@@ -88,9 +90,30 @@ services:
     networks:
       - infradev
 
+  nats-init:
+    image: natsio/nats-box
+    environment:
+      - NSC_HOME=/nsc
+    volumes:
+      - ./nsc:/nsc
+      - ./nats:/nats
+      - ./scripts:/scripts
+    command:
+      - /scripts/nats_init.sh
+
   nats:
-    image: 'nats:2'
-    network_mode: service:app
+    image: 'nats:alpine'
+    depends_on:
+      - nats-init
+    command:
+      - -c
+      - '/etc/nats/nats-server.conf'
+      - -D
+    volumes:
+      - ./nats/:/etc/nats
+    restart: unless-stopped
+    networks:
+      - infradev
 
   jaeger:
     image: jaegertracing/all-in-one:1.44.0

--- a/.devcontainer/nats/nats-server.conf
+++ b/.devcontainer/nats/nats-server.conf
@@ -1,0 +1,32 @@
+server_name: nats
+
+ # Client port of 4222 on all interfaces
+ port: 4222
+
+ # HTTP monitoring port
+ monitor_port: 8222
+
+ # # This is for clustering multiple servers together.
+ # cluster {
+ #   name: "cluster1"
+ #   listen: 0.0.0.0:6222
+ #   routes = [nats://127.0.0.1:6222]
+ #   cluster_advertise: nats-server:6222
+ #   connect_retries: 0
+ # }
+
+ jetstream: enabled
+ jetstream {
+   store_dir: /data/jetstream
+   max_mem: 10M
+   max_file: 1G
+ }
+
+ debug: true
+ logtime: true
+
+ max_payload: 4MB
+ lame_duck_grace_period: 10s
+ lame_duck_duration: 30s
+
+ include "resolver.conf"

--- a/.devcontainer/scripts/nats_init.sh
+++ b/.devcontainer/scripts/nats_init.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# script to bootstrap a nats operator environment
+
+if nsc describe operator; then
+    echo "operator exists, not overwriting config"
+    exit 0
+fi
+
+echo "Cleaning up NATS environment"
+rm -rf /nsc/*
+
+echo "Creating NATS operator"
+nsc add operator --generate-signing-key --sys --name LOCAL
+nsc edit operator -u 'nats://nats:4222'
+nsc list operators
+nsc describe operator
+
+export OPERATOR_SIGNING_KEY_ID=`nsc describe operator -J | jq -r '.nats.signing_keys | first'`
+
+echo "Creating NATS account for permissions-api"
+nsc add account -n INFRADEV -K ${OPERATOR_SIGNING_KEY_ID}
+nsc edit account INFRADEV --sk generate --js-mem-storage -1 --js-disk-storage -1 --js-streams -1 --js-consumer -1
+nsc describe account INFRADEV
+
+export ACCOUNTS_SIGNING_KEY_ID=`nsc describe account INFRADEV -J | jq -r '.nats.signing_keys | first'`
+
+echo "Creating NATS user for permissions-api"
+nsc add user -n USER -K ${ACCOUNTS_SIGNING_KEY_ID}
+nsc describe user USER
+
+echo "Generating NATS resolver.conf"
+nsc generate config --mem-resolver --sys-account SYS --config-file /nats/resolver.conf --force

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,9 @@
 # Emacs stuff
 *~
 
-# Ignore .tools dir
+# .tools dir
 .tools/
+
+# NATS dirs
+.devcontainer/nats/
+.devcontainer/nsc/

--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,4 @@
 .tools/
 
 # NATS dirs
-.devcontainer/nats/
 .devcontainer/nsc/

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,26 @@ CONTAINER_REPO?=ghcr.io/infratographer
 PERMISSIONS_API_CONTAINER_IMAGE_NAME = $(CONTAINER_REPO)/permissions-api
 CONTAINER_TAG?=latest
 
+# NATS settings
+NATS_CREDS?=/tmp/user.creds
+
 # Tool Versions
 GCI_REPO = github.com/daixiang0/gci
 GCI_VERSION = v0.10.1
 
 GOLANGCI_LINT_REPO = github.com/golangci/golangci-lint
 GOLANGCI_LINT_VERSION = v1.51.2
+
+NATS_CLI_REPO = github.com/nats-io/natscli
+NATS_CLI_VERSION = v0.0.35
+
+NATS_NSC_VERSION = v2.8.0
+
+NATS_NK_REPO = github.com/nats-io/nkeys
+NATS_NK_VERSION = latest
+
+ZED_REPO = github.com/authzed/zed
+ZED_VERSION = v0.10.1
 
 # go files to be checked
 GO_FILES=$(shell git ls-files '*.go')
@@ -72,6 +86,12 @@ gci-write: $(GO_FILES) | $(TOOLS_DIR)/gci  ## Checks and updates all go files fo
 
 gci: | gci-diff gci-write  ## Outputs and corrects all improper go import ordering.
 
+.PHONY: nats-account
+nats-account: | $(TOOLS_DIR)/nsc ## Generates NATS user account credentials.
+	@sudo chown -Rh vscode:vscode $(ROOT_DIR)/.devcontainer/nsc
+	@echo "Dumping NATS user creds file"
+	@$(TOOLS_DIR)/nsc --data-dir=$(ROOT_DIR)/.devcontainer/nsc/nats/nsc/stores generate creds -a INFRADEV -n USER > $(NATS_CREDS)
+
 image:  ## Builds all docker images.
 	$(CONTAINER_BUILD_CMD) -f Dockerfile . -t $(PERMISSIONS_API_CONTAINER_IMAGE_NAME):$(CONTAINER_TAG)
 
@@ -85,7 +105,6 @@ dev-infra-down:  ## Stops local services used for local development.
 	@echo Stopping services
 	@pushd .devcontainer && docker compose down && popd
 
-# Tools setup
 $(TOOLS_DIR):
 	mkdir -p $(TOOLS_DIR)
 
@@ -99,3 +118,19 @@ $(TOOLS_DIR)/golangci-lint: | $(TOOLS_DIR)
 	@GOBIN=$(ROOT_DIR)/$(TOOLS_DIR) go install $(GOLANGCI_LINT_REPO)/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 	$@ version
 	$@ linters
+
+$(TOOLS_DIR)/nsc: | $(TOOLS_DIR)
+	@echo "Installing NATS tooling"
+	@curl -o $(TOOLS_DIR)/nats_install.sh https://raw.githubusercontent.com/nats-io/nsc/$(NATS_NSC_VERSION)/install.sh
+	@chmod +x $(TOOLS_DIR)/nats_install.sh
+	@$(TOOLS_DIR)/nats_install.sh -s $(ROOT_DIR)/$(TOOLS_DIR)
+	@rm $(TOOLS_DIR)/nats_install.sh
+
+$(TOOLS_DIR)/nats: | $(TOOLS_DIR)
+	@GOBIN=$(ROOT_DIR)/$(TOOLS_DIR) go install $(NATS_CLI_REPO)/nats@$(NATS_CLI_VERSION)
+
+$(TOOLS_DIR)/zed: | $(TOOLS_DIR)
+	@GOBIN=$(ROOT_DIR)/$(TOOLS_DIR) go install $(ZED_REPO)/cmd/zed@$(ZED_VERSION)
+
+.PHONY: tools
+tools: $(TOOLS_DIR)/gci $(TOOLS_DIR)/golangci-lint $(TOOLS_DIR)/nsc $(TOOLS_DIR)/nats $(TOOLS_DIR)/zed ## Installs development tools.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"syscall"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -58,9 +59,9 @@ func init() {
 	rootCmd.PersistentFlags().String("spicedb-prefix", "", "spicedb prefix")
 	viperx.MustBindFlag(viper.GetViper(), "spicedb.prefix", rootCmd.PersistentFlags().Lookup("spicedb-prefix"))
 
-	// Set up SIGINT listener
+	// Set up SIGINT/SIGTERM listener
 	sigCh = make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"log"
 	"os"
+	"os/signal"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -20,6 +21,7 @@ var (
 	cfgFile   string
 	logger    *zap.SugaredLogger
 	globalCfg *config.AppConfig
+	sigCh     chan os.Signal
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -55,6 +57,10 @@ func init() {
 	viperx.MustBindFlag(viper.GetViper(), "spicedb.verifyca", rootCmd.PersistentFlags().Lookup("spicedb-verifyca"))
 	rootCmd.PersistentFlags().String("spicedb-prefix", "", "spicedb prefix")
 	viperx.MustBindFlag(viper.GetViper(), "spicedb.prefix", rootCmd.PersistentFlags().Lookup("spicedb-prefix"))
+
+	// Set up SIGINT listener
+	sigCh = make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -59,7 +59,7 @@ func worker(ctx context.Context, cfg *config.AppConfig) {
 
 	logger.Infow("client config", "client_config", cfg.PubSub)
 
-	client, err := pubsub.NewClient(
+	client := pubsub.NewClient(
 		cfg.PubSub,
 		pubsub.WithQueryEngine(engine),
 		pubsub.WithResourceTypeNames(
@@ -69,13 +69,8 @@ func worker(ctx context.Context, cfg *config.AppConfig) {
 		),
 		pubsub.WithLogger(logger),
 	)
-	if err != nil {
-		logger.Fatalw("error starting NATS client", "error", err)
-	}
 
-	err = client.Listen()
-
-	if err != nil {
+	if err := client.Listen(); err != nil {
 		logger.Fatalw("error listening for events", "error", err)
 	}
 

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -1,0 +1,89 @@
+/*
+Copyright © 2022 The Infratographer Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.infratographer.com/x/otelx"
+
+	"go.infratographer.com/permissions-api/internal/config"
+	"go.infratographer.com/permissions-api/internal/pubsub"
+	"go.infratographer.com/permissions-api/internal/query"
+	"go.infratographer.com/permissions-api/internal/spicedbx"
+)
+
+var workerCmd = &cobra.Command{
+	Use:   "worker",
+	Short: "starts a permissions-api queue worker",
+	Run: func(cmd *cobra.Command, args []string) {
+		worker(cmd.Context(), globalCfg)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(workerCmd)
+
+	otelx.MustViperFlags(viper.GetViper(), workerCmd.Flags())
+	pubsub.MustViperFlags(viper.GetViper(), workerCmd.Flags())
+}
+
+func worker(ctx context.Context, cfg *config.AppConfig) {
+	err := otelx.InitTracer(cfg.Tracing, appName, logger)
+	if err != nil {
+		logger.Fatalw("unable to initialize tracing system", "error", err)
+	}
+
+	spiceClient, err := spicedbx.NewClient(cfg.SpiceDB, cfg.Tracing.Enabled)
+	if err != nil {
+		logger.Fatalw("unable to initialize spicedb client", "error", err)
+	}
+
+	engine := query.NewEngine("infratographer", spiceClient)
+
+	logger.Infow("client config", "client_config", cfg.PubSub)
+
+	client, err := pubsub.NewClient(
+		cfg.PubSub,
+		pubsub.WithQueryEngine(engine),
+		pubsub.WithResourceTypeNames(
+			[]string{
+				"tenant",
+			},
+		),
+		pubsub.WithLogger(logger),
+	)
+	if err != nil {
+		logger.Fatalw("error starting NATS client", "error", err)
+	}
+
+	err = client.Listen()
+
+	if err != nil {
+		logger.Fatalw("error listening for events", "error", err)
+	}
+
+	// Wait until we're told to stop
+	<-sigCh
+
+	err = client.Stop()
+	if err != nil {
+		logger.Fatalw("error stopping NATS client", "error", err)
+	}
+}

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -80,7 +80,9 @@ func worker(ctx context.Context, cfg *config.AppConfig) {
 	}
 
 	// Wait until we're told to stop
-	<-sigCh
+	sig := <-sigCh
+
+	logger.Infof("received %s signal, stopping", sig)
 
 	err = client.Stop()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/authzed/grpcutil v0.0.0-20230109193425-40ce0530e048
 	github.com/google/uuid v1.3.0
 	github.com/labstack/echo/v4 v4.10.2
+	github.com/nats-io/nats-server/v2 v2.9.16
 	github.com/nats-io/nats.go v1.24.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
@@ -31,6 +32,7 @@ require (
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.9.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
@@ -45,6 +47,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jzelinskie/stringz v0.0.0-20210414224931-d6a8ce844a70 // indirect
+	github.com/klauspost/compress v1.16.4 // indirect
 	github.com/labstack/echo-contrib v0.14.1 // indirect
 	github.com/labstack/echo-jwt/v4 v4.1.0 // indirect
 	github.com/labstack/gommon v0.4.0 // indirect
@@ -52,10 +55,12 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/minio/highwayhash v1.0.2 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/nats-io/nats-server/v2 v2.9.16 // indirect
+	github.com/nats-io/jsm.go v0.0.35 // indirect
+	github.com/nats-io/jwt/v2 v2.4.1 // indirect
 	github.com/nats-io/nkeys v0.4.4 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
@@ -68,6 +73,7 @@ require (
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/authzed/grpcutil v0.0.0-20230109193425-40ce0530e048
 	github.com/google/uuid v1.3.0
 	github.com/labstack/echo/v4 v4.10.2
+	github.com/nats-io/nats.go v1.24.0
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
 	go.infratographer.com/x v0.0.7
@@ -53,6 +55,9 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/nats-io/nats-server/v2 v2.9.16 // indirect
+	github.com/nats-io/nkeys v0.4.4 // indirect
+	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
@@ -63,7 +68,6 @@ require (
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
@@ -79,7 +83,7 @@ require (
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
-	golang.org/x/crypto v0.7.0 // indirect
+	golang.org/x/crypto v0.8.0 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.9.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
@@ -59,7 +58,6 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/nats-io/jsm.go v0.0.35 // indirect
 	github.com/nats-io/jwt/v2 v2.4.1 // indirect
 	github.com/nats-io/nkeys v0.4.4 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -203,6 +205,7 @@ github.com/jzelinskie/stringz v0.0.0-20210414224931-d6a8ce844a70/go.mod h1:hHYbg
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.16.4 h1:91KN02FnsOYhuunwU4ssRe8lc2JosWmizWa91B5v1PU=
+github.com/klauspost/compress v1.16.4/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -236,6 +239,7 @@ github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
+github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -243,7 +247,10 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/nats-io/jsm.go v0.0.35 h1:l03xuGttRA9b81Q0P/WEGm3e5DYof743ZEI4nQR3PUs=
+github.com/nats-io/jsm.go v0.0.35/go.mod h1:AkNKZTxbvdFBOJCdlKuLHsRlOP+AI4hV9REQKmq3sWw=
 github.com/nats-io/jwt/v2 v2.4.1 h1:Y35W1dgbbz2SQUYDPCaclXcuqleVmpbRa7646Jf2EX4=
+github.com/nats-io/jwt/v2 v2.4.1/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+vu/+ibI=
 github.com/nats-io/nats-server/v2 v2.9.16 h1:SuNe6AyCcVy0g5326wtyU8TdqYmcPqzTjhkHojAjprc=
 github.com/nats-io/nats-server/v2 v2.9.16/go.mod h1:z1cc5Q+kqJkz9mLUdlcSsdYnId4pyImHjNgoh6zxSC0=
 github.com/nats-io/nats.go v1.24.0 h1:CRiD8L5GOQu/DcfkmgBcTTIQORMwizF+rPk6T0RaHVQ=
@@ -465,6 +472,7 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190130150945-aca44879d564/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
-github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
-github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -247,8 +245,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/nats-io/jsm.go v0.0.35 h1:l03xuGttRA9b81Q0P/WEGm3e5DYof743ZEI4nQR3PUs=
-github.com/nats-io/jsm.go v0.0.35/go.mod h1:AkNKZTxbvdFBOJCdlKuLHsRlOP+AI4hV9REQKmq3sWw=
 github.com/nats-io/jwt/v2 v2.4.1 h1:Y35W1dgbbz2SQUYDPCaclXcuqleVmpbRa7646Jf2EX4=
 github.com/nats-io/jwt/v2 v2.4.1/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+vu/+ibI=
 github.com/nats-io/nats-server/v2 v2.9.16 h1:SuNe6AyCcVy0g5326wtyU8TdqYmcPqzTjhkHojAjprc=

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,7 @@ github.com/jzelinskie/stringz v0.0.0-20210414224931-d6a8ce844a70 h1:thTca5Eyouk5
 github.com/jzelinskie/stringz v0.0.0-20210414224931-d6a8ce844a70/go.mod h1:hHYbgxJuNLRw91CmpuFsYEOyQqpDVFg8pvEh23vy4P0=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.16.4 h1:91KN02FnsOYhuunwU4ssRe8lc2JosWmizWa91B5v1PU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -234,6 +235,7 @@ github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPn
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -241,6 +243,15 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/nats-io/jwt/v2 v2.4.1 h1:Y35W1dgbbz2SQUYDPCaclXcuqleVmpbRa7646Jf2EX4=
+github.com/nats-io/nats-server/v2 v2.9.16 h1:SuNe6AyCcVy0g5326wtyU8TdqYmcPqzTjhkHojAjprc=
+github.com/nats-io/nats-server/v2 v2.9.16/go.mod h1:z1cc5Q+kqJkz9mLUdlcSsdYnId4pyImHjNgoh6zxSC0=
+github.com/nats-io/nats.go v1.24.0 h1:CRiD8L5GOQu/DcfkmgBcTTIQORMwizF+rPk6T0RaHVQ=
+github.com/nats-io/nats.go v1.24.0/go.mod h1:dVQF+BK3SzUZpwyzHedXsvH3EO38aVKuOPkkHlv5hXA=
+github.com/nats-io/nkeys v0.4.4 h1:xvBJ8d69TznjcQl9t6//Q5xXuVhyYiSos6RPtvQNTwA=
+github.com/nats-io/nkeys v0.4.4/go.mod h1:XUkxdLPTufzlihbamfzQ7mw/VGx6ObUs+0bN5sNvt64=
+github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
+github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pelletier/go-toml/v2 v2.0.6 h1:nrzqCb7j9cDFj2coyLNLaZuJTLjWjlaz6nvTvIwycIU=
 github.com/pelletier/go-toml/v2 v2.0.6/go.mod h1:eumQOmlWiOPt5WriQQqoM5y18pDHwha2N+QD+EUNTek=
@@ -362,8 +373,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
-golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
+golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
+golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -17,12 +17,12 @@ var tracer = otel.Tracer("go.infratographer.com/permissions-api/internal/api")
 // Router provides a router for the API
 type Router struct {
 	authMW echo.MiddlewareFunc
-	engine *query.Engine
+	engine query.Engine
 	logger *zap.SugaredLogger
 }
 
 // NewRouter returns a new api router
-func NewRouter(authCfg echojwtx.AuthConfig, engine *query.Engine, l *zap.SugaredLogger) (*Router, error) {
+func NewRouter(authCfg echojwtx.AuthConfig, engine query.Engine, l *zap.SugaredLogger) (*Router, error) {
 	// Ensure auth is skipped for default endpoints.
 	authCfg.JWTConfig.Skipper = echox.SkipDefaultEndpoints
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"go.infratographer.com/x/loggingx"
 	"go.infratographer.com/x/otelx"
 
+	"go.infratographer.com/permissions-api/internal/pubsub"
 	"go.infratographer.com/permissions-api/internal/spicedbx"
 )
 
@@ -17,4 +18,5 @@ type AppConfig struct {
 	Server  echox.Config
 	SpiceDB spicedbx.Config
 	Tracing otelx.Config
+	PubSub  pubsub.Config
 }

--- a/internal/pubsub/config.go
+++ b/internal/pubsub/config.go
@@ -1,0 +1,34 @@
+package pubsub
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"go.infratographer.com/x/viperx"
+)
+
+// Config represents a NATS pubsub config.
+type Config struct {
+	Name        string
+	Credentials string
+	Server      string
+	Stream      string
+	Prefix      string
+}
+
+// MustViperFlags sets required Viper flags for the pubsub package.
+func MustViperFlags(v *viper.Viper, flags *pflag.FlagSet) {
+	flags.String("pubsub-name", "", "pubsub consumer name")
+	viperx.MustBindFlag(viper.GetViper(), "pubsub.name", flags.Lookup("pubsub-name"))
+
+	flags.String("pubsub-credentials", "", "pubsub consumer credentials file")
+	viperx.MustBindFlag(viper.GetViper(), "pubsub.credentials", flags.Lookup("pubsub-credentials"))
+
+	flags.String("pubsub-server", "", "pubsub server")
+	viperx.MustBindFlag(viper.GetViper(), "pubsub.server", flags.Lookup("pubsub-server"))
+
+	flags.String("pubsub-stream", "", "pubsub stream")
+	viperx.MustBindFlag(viper.GetViper(), "pubsub.stream", flags.Lookup("pubsub-stream"))
+
+	flags.String("pubsub-prefix", "", "pubsub subject prefix")
+	viperx.MustBindFlag(viper.GetViper(), "pubsub.prefix", flags.Lookup("pubsub-prefix"))
+}

--- a/internal/pubsub/config.go
+++ b/internal/pubsub/config.go
@@ -6,12 +6,17 @@ import (
 	"go.infratographer.com/x/viperx"
 )
 
+const (
+	defaultConsumer = "permissions-api-worker"
+)
+
 // Config represents a NATS pubsub config.
 type Config struct {
 	Name        string
 	Credentials string
 	Server      string
 	Stream      string
+	Consumer    string
 	Prefix      string
 }
 
@@ -28,6 +33,9 @@ func MustViperFlags(v *viper.Viper, flags *pflag.FlagSet) {
 
 	flags.String("pubsub-stream", "", "pubsub stream")
 	viperx.MustBindFlag(viper.GetViper(), "pubsub.stream", flags.Lookup("pubsub-stream"))
+
+	flags.String("pubsub-consumer", defaultConsumer, "pubsub consumer")
+	viperx.MustBindFlag(viper.GetViper(), "pubsub.consumer", flags.Lookup("pubsub-consumer"))
 
 	flags.String("pubsub-prefix", "", "pubsub subject prefix")
 	viperx.MustBindFlag(viper.GetViper(), "pubsub.prefix", flags.Lookup("pubsub-prefix"))

--- a/internal/pubsub/doc.go
+++ b/internal/pubsub/doc.go
@@ -1,0 +1,2 @@
+// Package pubsub provides functions and data for a NATS consumer listening for resource lifecycle events.
+package pubsub

--- a/internal/pubsub/subscriber.go
+++ b/internal/pubsub/subscriber.go
@@ -178,6 +178,9 @@ func (c *Client) Listen() error {
 		nats.AckExplicit(),
 	}
 
+	// For each resource type, we create a single subscription. This means that a single worker
+	// process exists for each resource type, which may be a limiting factor if some resource
+	// subjects are chattier than others
 	for _, name := range c.resourceTypeNames {
 		subject := fmt.Sprintf("%s.%s.>", c.prefix, name)
 		queueName := fmt.Sprintf("%s-%s", c.consumer, name)

--- a/internal/pubsub/subscriber.go
+++ b/internal/pubsub/subscriber.go
@@ -1,0 +1,196 @@
+package pubsub
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.infratographer.com/permissions-api/internal/query"
+	"go.infratographer.com/x/pubsubx"
+	"go.infratographer.com/x/urnx"
+	"go.uber.org/zap"
+
+	"github.com/nats-io/nats.go"
+)
+
+const (
+	drainTimeout = 1 * time.Second
+)
+
+// Client represents a NATS JetStream client listening for resource lifecycle events.
+type Client struct {
+	logger            *zap.SugaredLogger
+	nc                *nats.Conn
+	js                nats.JetStreamContext
+	stream            string
+	prefix            string
+	subscriptions     []*nats.Subscription
+	resourceTypeNames []string
+	qe                *query.Engine
+}
+
+// ClientOpt represents a non-config setting for a client.
+type ClientOpt func(*Client)
+
+// WithLogger sets the client logger to the given logger.
+func WithLogger(l *zap.SugaredLogger) ClientOpt {
+	return func(c *Client) {
+		c.logger = l
+	}
+}
+
+// WithResourceTypeNames sets the resource type names for the client to listen for.
+func WithResourceTypeNames(typeNames []string) ClientOpt {
+	return func(c *Client) {
+		c.resourceTypeNames = typeNames
+	}
+}
+
+// WithQueryEngine sets the query engine for the client.
+func WithQueryEngine(e *query.Engine) ClientOpt {
+	return func(c *Client) {
+		c.qe = e
+	}
+}
+
+// NewClient creates a new pubsub client.
+func NewClient(cfg Config, opts ...ClientOpt) (*Client, error) {
+	natsOpts := []nats.Option{
+		nats.Name(cfg.Name),
+		nats.UserCredentials(cfg.Credentials),
+		nats.DrainTimeout(drainTimeout),
+	}
+
+	nc, err := nats.Connect(cfg.Server, natsOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	js, err := nc.JetStream()
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Client{
+		nc:     nc,
+		js:     js,
+		stream: cfg.Stream,
+		prefix: cfg.Prefix,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c, nil
+}
+
+func (c *Client) ensureStream() error {
+	c.logger.Debugw("checking that NATS stream exists", "stream_name", c.stream)
+
+	_, err := c.js.StreamInfo(c.stream)
+	if err == nil {
+		c.logger.Debugw("stream exists, not recreating", "stream_name", c.stream)
+		return nil
+	}
+
+	if !errors.Is(err, nats.ErrStreamNotFound) {
+		return err
+	}
+
+	_, err = c.js.AddStream(&nats.StreamConfig{
+		Name: c.stream,
+		Subjects: []string{
+			c.prefix + ".>",
+		},
+		Storage:   nats.FileStorage,
+		Retention: nats.LimitsPolicy,
+		Discard:   nats.DiscardNew,
+	})
+
+	return err
+}
+
+// Listen ensures a stream exists, binds to it, and listens for resource lifecycle events on that stream.
+func (c *Client) Listen() error {
+	// Ensure stream exists before we attempt to listen on it
+	err := c.ensureStream()
+	if err != nil {
+		return err
+	}
+
+	// Set subscription options. We specifically want manual acks in case something goes wrong
+	// persisting the event
+	subOpts := []nats.SubOpt{
+		nats.BindStream(c.stream),
+		nats.ManualAck(),
+	}
+
+	for _, name := range c.resourceTypeNames {
+		subject := fmt.Sprintf("%s.%s.>", c.prefix, name)
+		queueName := fmt.Sprintf("permissions-api-worker-%s", name)
+
+		subscription, err := c.js.QueueSubscribe(subject, queueName, c.receiveMsg, subOpts...)
+		if err != nil {
+			return err
+		}
+
+		c.subscriptions = append(c.subscriptions, subscription)
+	}
+
+	return nil
+}
+
+// Stop drains all subscriptions for the client.
+func (c *Client) Stop() error {
+	for _, sub := range c.subscriptions {
+		err := sub.Drain()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) termMsg(msg *nats.Msg, err error) {
+	c.logger.Warnw("invalid message - will not reprocess", "error", err.Error())
+
+	err = msg.Term()
+	if err != nil {
+		c.logger.Errorw("error terminating message", "error", err.Error())
+	}
+}
+
+func (c *Client) receiveMsg(msg *nats.Msg) {
+	var payload pubsubx.Message
+
+	err := json.Unmarshal(msg.Data, &payload)
+	if err != nil {
+		c.termMsg(msg, err)
+
+		return
+	}
+
+	resourceURN, err := urnx.Parse(payload.SubjectURN)
+	if err != nil {
+		c.termMsg(msg, err)
+
+		return
+	}
+
+	resource, err := c.qe.NewResourceFromURN(resourceURN)
+	if err != nil {
+		c.termMsg(msg, err)
+
+		return
+	}
+
+	c.logger.Infow("received message", "resource_type", resource.Type, "resource_id", resource.ID.String(), "event", payload.EventType)
+
+	err = msg.Ack()
+	if err != nil {
+		c.logger.Errorw("error acking message", "error", err.Error())
+	}
+}

--- a/internal/pubsub/subscriber_test.go
+++ b/internal/pubsub/subscriber_test.go
@@ -1,0 +1,350 @@
+package pubsub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"go.infratographer.com/permissions-api/internal/query/mock"
+	"go.infratographer.com/permissions-api/internal/testingx"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/require"
+)
+
+type contextKey int
+
+var (
+	errNoAck = errors.New("no Ack received within time limit")
+	errNak   = errors.New("received Nak")
+)
+
+const (
+	startTimeout     = 5 * time.Second
+	natsUsername     = "natsuser"
+	natsPassword     = "natspassword"
+	natsConsumerName = "worker"
+
+	contextKeyClient contextKey = iota
+	contextKeyPublisher
+)
+
+func newNATSServer(t *testing.T) *natsserver.Server {
+	opts := natsserver.Options{
+		Host:     "127.0.0.1",
+		Port:     natsserver.RANDOM_PORT,
+		Username: natsUsername,
+		Password: natsPassword,
+	}
+
+	server := natsserver.New(&opts)
+
+	go server.Start()
+
+	t.Cleanup(func() {
+		server.Shutdown()
+	})
+
+	if !server.ReadyForConnections(startTimeout) {
+		require.Fail(t, "NATS server failed to start")
+	}
+
+	jsConfig := natsserver.JetStreamConfig{
+		StoreDir: t.TempDir(),
+	}
+
+	err := server.EnableJetStream(&jsConfig)
+	require.NoError(t, err)
+
+	return server
+}
+
+func newNATSConn(t *testing.T, addr, name string) *nats.Conn {
+	natsOpts := []nats.Option{
+		nats.Name(name),
+		nats.UserInfo(natsUsername, natsPassword),
+	}
+
+	nc, err := nats.Connect(addr, natsOpts...)
+
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		nc.Close()
+	})
+
+	return nc
+}
+
+func setupClient(t *testing.T, engine mock.MockEngine, addr, testName string) *Client {
+	// Create a new NATS connection
+	subConn := newNATSConn(t, addr, testName)
+
+	// Create a new client with a stream based on the test name
+	config := Config{
+		Name:     "subscriber",
+		Stream:   testName,
+		Consumer: natsConsumerName,
+		Prefix:   testName,
+	}
+
+	client, err := NewClient(
+		config,
+		WithConn(subConn),
+		WithResourceTypeNames(
+			[]string{
+				"loadbalancer",
+			},
+		),
+		WithQueryEngine(&engine),
+	)
+
+	require.NoError(t, err)
+
+	err = client.Listen()
+	require.NoError(t, err)
+
+	// Update the stream's consumer to sample all Acks for observability so we can see when a message was processed
+	info, err := client.js.ConsumerInfo(testName, natsConsumerName)
+	require.NoError(t, err)
+
+	cfg := info.Config
+	cfg.SampleFrequency = "100"
+
+	_, err = client.js.UpdateConsumer(testName, &cfg)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		client.Stop()
+	})
+
+	return client
+}
+
+func waitForAck(nc *nats.Conn, client *Client, timeout time.Duration) error {
+	ackSubject := fmt.Sprintf("$JS.EVENT.METRIC.CONSUMER.ACK.%s.%s", client.stream, client.consumer)
+
+	nakSubject := fmt.Sprintf("$JS.EVENT.ADVISORY.CONSUMER.MSG_NAKED.%s.%s", client.stream, client.consumer)
+
+	// We should only ever receive one Ack, so we close the channel directly if we get one.
+	ackCh := make(chan struct{})
+	nc.Subscribe(ackSubject, func(m *nats.Msg) {
+		close(ackCh)
+	})
+
+	// We may receive many Naks in a single test, so we use a sync.Once to close the channel.
+	nakCh := make(chan struct{})
+	var nakOnce sync.Once
+	nc.Subscribe(nakSubject, func(m *nats.Msg) {
+		nakOnce.Do(func() {
+			close(nakCh)
+		})
+	})
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-ackCh:
+		return nil
+	case <-nakCh:
+		return errNak
+	case <-timer.C:
+		return errNoAck
+	}
+}
+
+func contextWithPublisher(ctx context.Context, t *testing.T, addr string) context.Context {
+	pubConn := newNATSConn(t, addr, "publisher")
+
+	return context.WithValue(ctx, contextKeyPublisher, pubConn)
+}
+
+func makeClientSetupFn(addr, testName string) func(context.Context, *testing.T) context.Context {
+	return func(ctx context.Context, t *testing.T) context.Context {
+		client := setupClient(t, mock.MockEngine{}, addr, testName)
+
+		return context.WithValue(ctx, contextKeyClient, client)
+	}
+}
+
+func getContextPublisher(ctx context.Context) *nats.Conn {
+	return ctx.Value(contextKeyPublisher).(*nats.Conn)
+}
+
+func getContextClient(ctx context.Context) *Client {
+	return ctx.Value(contextKeyClient).(*Client)
+}
+
+func TestNATS(t *testing.T) {
+	server := newNATSServer(t)
+	addr := server.Addr().String()
+
+	type testInput struct {
+		subject  string
+		msgBytes []byte
+	}
+
+	createBytes := []byte(`{"subject_urn": "urn:infratographer:loadbalancer:fc065394-5486-4731-93b4-2726ca7e669f", "event_type": "create", "fields": {"tenant_urn": "urn:infratographer:tenant:75c8ec25-86e8-4fa7-93e2-6167684c3fb6"}}`)
+	updateBytes := []byte(`{"subject_urn": "urn:infratographer:loadbalancer:fc065394-5486-4731-93b4-2726ca7e669f", "event_type": "update", "fields": {"tenant_urn": "urn:infratographer:tenant:75c8ec25-86e8-4fa7-93e2-6167684c3fb6"}}`)
+	deleteBytes := []byte(`{"subject_urn": "urn:infratographer:loadbalancer:fc065394-5486-4731-93b4-2726ca7e669f", "event_type": "delete"}`)
+	unknownResourceBytes := []byte(`{"subject_urn": "urn:infratographer:badresource:fc065394-5486-4731-93b4-2726ca7e669f", "event_type": "create"}`)
+
+	// Each of these tests works as follows:
+	// - A publisher NATS connection is created
+	// - A client is created with a mocked engine that has its own dedicated stream and subject prefix
+	// - The client's consumer is updated to emit events for all message Acks
+	// - The publisher publishes a message
+	// - The publisher also subscribes to JetStream events to listen for either an explicit Ack or Nak
+	//
+	// When writing tests, make sure the subject prefix in the test input matches the prefix provided in
+	// setupClient, or else you will get undefined, racy behavior.
+	testCases := []testingx.TestCase[testInput, *Client]{
+		{
+			Name: "goodcreate",
+			Input: testInput{
+				subject:  "goodcreate.loadbalancer.create",
+				msgBytes: createBytes,
+			},
+			SetupFn: func(ctx context.Context, t *testing.T) context.Context {
+				ctx = contextWithPublisher(ctx, t, addr)
+
+				var engine mock.MockEngine
+				engine.On("CreateRelationships").Return("", nil)
+
+				client := setupClient(t, engine, addr, "goodcreate")
+
+				return context.WithValue(ctx, contextKeyClient, client)
+			},
+			CheckFn: func(ctx context.Context, t *testing.T, result testingx.TestResult[*Client]) {
+				require.NoError(t, result.Err)
+
+				engine := result.Success.qe.(*mock.MockEngine)
+				engine.AssertExpectations(t)
+			},
+		},
+		{
+			Name: "errcreate",
+			Input: testInput{
+				subject:  "errcreate.loadbalancer.create",
+				msgBytes: createBytes,
+			},
+			SetupFn: func(ctx context.Context, t *testing.T) context.Context {
+				ctx = contextWithPublisher(ctx, t, addr)
+
+				var engine mock.MockEngine
+				engine.On("CreateRelationships").Return("", errors.New("eep!"))
+
+				client := setupClient(t, engine, addr, "errcreate")
+
+				return context.WithValue(ctx, contextKeyClient, client)
+			},
+			CheckFn: func(ctx context.Context, t *testing.T, result testingx.TestResult[*Client]) {
+				require.ErrorIs(t, result.Err, errNak)
+			},
+		},
+		{
+			Name: "goodupdate",
+			Input: testInput{
+				subject:  "goodupdate.loadbalancer.update",
+				msgBytes: updateBytes,
+			},
+			SetupFn: func(ctx context.Context, t *testing.T) context.Context {
+				ctx = contextWithPublisher(ctx, t, addr)
+
+				var engine mock.MockEngine
+				engine.On("DeleteRelationships").Return("", nil)
+				engine.On("CreateRelationships").Return("", nil)
+
+				client := setupClient(t, engine, addr, "goodupdate")
+
+				return context.WithValue(ctx, contextKeyClient, client)
+			},
+			CheckFn: func(ctx context.Context, t *testing.T, result testingx.TestResult[*Client]) {
+				require.NoError(t, result.Err)
+
+				engine := result.Success.qe.(*mock.MockEngine)
+				engine.AssertExpectations(t)
+			},
+		},
+		{
+			Name: "gooddelete",
+			Input: testInput{
+				subject:  "gooddelete.loadbalancer.delete",
+				msgBytes: deleteBytes,
+			},
+			SetupFn: func(ctx context.Context, t *testing.T) context.Context {
+				ctx = contextWithPublisher(ctx, t, addr)
+
+				var engine mock.MockEngine
+				engine.Namespace = "gooddelete"
+				engine.On("DeleteRelationships").Return("", nil)
+
+				client := setupClient(t, engine, addr, "gooddelete")
+
+				return context.WithValue(ctx, contextKeyClient, client)
+			},
+			CheckFn: func(ctx context.Context, t *testing.T, result testingx.TestResult[*Client]) {
+				require.NoError(t, result.Err)
+
+				engine := result.Success.qe.(*mock.MockEngine)
+				engine.AssertExpectations(t)
+			},
+		},
+		{
+			Name: "badresource",
+			Input: testInput{
+				subject:  "badresource.fakeresource.create",
+				msgBytes: unknownResourceBytes,
+			},
+			SetupFn: func(ctx context.Context, t *testing.T) context.Context {
+				ctx = contextWithPublisher(ctx, t, addr)
+
+				var engine mock.MockEngine
+
+				client := setupClient(t, engine, addr, "badresource")
+
+				return context.WithValue(ctx, contextKeyClient, client)
+			},
+			CheckFn: func(ctx context.Context, t *testing.T, result testingx.TestResult[*Client]) {
+				require.ErrorIs(t, result.Err, errNoAck)
+			},
+		},
+	}
+
+	testFn := func(ctx context.Context, input testInput) testingx.TestResult[*Client] {
+		pubConn := getContextPublisher(ctx)
+		client := getContextClient(ctx)
+
+		js, err := pubConn.JetStream()
+		if err != nil {
+			return testingx.TestResult[*Client]{
+				Err: err,
+			}
+		}
+
+		_, err = js.PublishAsync(input.subject, input.msgBytes)
+		if err != nil {
+			return testingx.TestResult[*Client]{
+				Err: err,
+			}
+		}
+
+		err = waitForAck(pubConn, client, 3*time.Second)
+		if err != nil {
+			return testingx.TestResult[*Client]{
+				Err: err,
+			}
+		}
+
+		return testingx.TestResult[*Client]{
+			Success: client,
+		}
+	}
+
+	testingx.RunTests(context.Background(), t, testCases, testFn)
+}

--- a/internal/query/mock/doc.go
+++ b/internal/query/mock/doc.go
@@ -1,0 +1,2 @@
+// Package mock contains a mock implementation of the query.Engine interface.
+package mock

--- a/internal/query/mock/mock.go
+++ b/internal/query/mock/mock.go
@@ -1,0 +1,99 @@
+package mock
+
+import (
+	"context"
+
+	"go.infratographer.com/permissions-api/internal/query"
+	"go.infratographer.com/permissions-api/internal/types"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"go.infratographer.com/x/urnx"
+)
+
+var (
+	_ query.Engine = &MockEngine{}
+)
+
+// MockEngine represents an engine that does nothing and accepts all resource types.
+type MockEngine struct {
+	mock.Mock
+	Namespace string
+}
+
+// AssignSubjectRole does nothing but satisfies the Engine interface.
+func (e *MockEngine) AssignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) (string, error) {
+	return "", nil
+}
+
+// CreateRelationships does nothing but satisfies the Engine interface.
+func (e *MockEngine) CreateRelationships(ctx context.Context, rels []types.Relationship) (string, error) {
+	args := e.Called()
+
+	return args.String(0), args.Error(1)
+}
+
+// CreateRole creates a Role object and does not persist it anywhere.
+func (e *MockEngine) CreateRole(ctx context.Context, res types.Resource, actions []string) (types.Role, string, error) {
+	// Copy actions instead of using the given slice
+	outActions := make([]string, len(actions))
+
+	copy(outActions, actions)
+
+	role := types.Role{
+		ID:      uuid.New(),
+		Actions: outActions,
+	}
+
+	return role, "", nil
+}
+
+// ListAssignments returns nothing but satisfies the Engine interface.
+func (e *MockEngine) ListAssignments(ctx context.Context, role types.Role, queryToken string) ([]types.Resource, error) {
+	// e.Called(ctx, role, queryToken)
+
+	return nil, nil
+}
+
+// ListRelationships returns nothing but satisfies the Engine interface.
+func (e *MockEngine) ListRelationships(ctx context.Context, resource types.Resource, queryToken string) ([]types.Relationship, error) {
+	// e.Called(ctx, resource, queryToken)
+
+	return nil, nil
+}
+
+// ListRoles returns nothing but satisfies the Engine interface.
+func (e *MockEngine) ListRoles(ctx context.Context, resource types.Resource, queryToken string) ([]types.Role, error) {
+	// e.Called(ctx, resource, queryToken)
+
+	return nil, nil
+}
+
+// DeleteRelationships does nothing but satisfies the Engine interface.
+func (e *MockEngine) DeleteRelationships(ctx context.Context, resource types.Resource) (string, error) {
+	args := e.Called()
+
+	return args.String(0), args.Error(1)
+}
+
+// NewResourceFromURN creates a new resource object based on the given URN.
+func (e *MockEngine) NewResourceFromURN(urn *urnx.URN) (types.Resource, error) {
+	out := types.Resource{
+		Type: urn.ResourceType,
+		ID:   urn.ResourceID,
+	}
+
+	return out, nil
+}
+
+// NewURNFromResource creates a new URN from the given resource.
+func (e *MockEngine) NewURNFromResource(res types.Resource) (*urnx.URN, error) {
+	return urnx.Build(e.Namespace, res.Type, res.ID)
+}
+
+// SubjectHasPermission returns nil to satisfy the Engine interface.
+func (e *MockEngine) SubjectHasPermission(ctx context.Context, subject types.Resource, action string, resource types.Resource, queryToken string) error {
+	e.Called()
+
+	return nil
+}

--- a/internal/query/mock/mock.go
+++ b/internal/query/mock/mock.go
@@ -12,29 +12,29 @@ import (
 )
 
 var (
-	_ query.Engine = &MockEngine{}
+	_ query.Engine = &Engine{}
 )
 
-// MockEngine represents an engine that does nothing and accepts all resource types.
-type MockEngine struct {
+// Engine represents an engine that does nothing and accepts all resource types.
+type Engine struct {
 	mock.Mock
 	Namespace string
 }
 
 // AssignSubjectRole does nothing but satisfies the Engine interface.
-func (e *MockEngine) AssignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) (string, error) {
+func (e *Engine) AssignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) (string, error) {
 	return "", nil
 }
 
 // CreateRelationships does nothing but satisfies the Engine interface.
-func (e *MockEngine) CreateRelationships(ctx context.Context, rels []types.Relationship) (string, error) {
+func (e *Engine) CreateRelationships(ctx context.Context, rels []types.Relationship) (string, error) {
 	args := e.Called()
 
 	return args.String(0), args.Error(1)
 }
 
 // CreateRole creates a Role object and does not persist it anywhere.
-func (e *MockEngine) CreateRole(ctx context.Context, res types.Resource, actions []string) (types.Role, string, error) {
+func (e *Engine) CreateRole(ctx context.Context, res types.Resource, actions []string) (types.Role, string, error) {
 	// Copy actions instead of using the given slice
 	outActions := make([]string, len(actions))
 
@@ -49,35 +49,29 @@ func (e *MockEngine) CreateRole(ctx context.Context, res types.Resource, actions
 }
 
 // ListAssignments returns nothing but satisfies the Engine interface.
-func (e *MockEngine) ListAssignments(ctx context.Context, role types.Role, queryToken string) ([]types.Resource, error) {
-	// e.Called(ctx, role, queryToken)
-
+func (e *Engine) ListAssignments(ctx context.Context, role types.Role, queryToken string) ([]types.Resource, error) {
 	return nil, nil
 }
 
 // ListRelationships returns nothing but satisfies the Engine interface.
-func (e *MockEngine) ListRelationships(ctx context.Context, resource types.Resource, queryToken string) ([]types.Relationship, error) {
-	// e.Called(ctx, resource, queryToken)
-
+func (e *Engine) ListRelationships(ctx context.Context, resource types.Resource, queryToken string) ([]types.Relationship, error) {
 	return nil, nil
 }
 
 // ListRoles returns nothing but satisfies the Engine interface.
-func (e *MockEngine) ListRoles(ctx context.Context, resource types.Resource, queryToken string) ([]types.Role, error) {
-	// e.Called(ctx, resource, queryToken)
-
+func (e *Engine) ListRoles(ctx context.Context, resource types.Resource, queryToken string) ([]types.Role, error) {
 	return nil, nil
 }
 
 // DeleteRelationships does nothing but satisfies the Engine interface.
-func (e *MockEngine) DeleteRelationships(ctx context.Context, resource types.Resource) (string, error) {
+func (e *Engine) DeleteRelationships(ctx context.Context, resource types.Resource) (string, error) {
 	args := e.Called()
 
 	return args.String(0), args.Error(1)
 }
 
 // NewResourceFromURN creates a new resource object based on the given URN.
-func (e *MockEngine) NewResourceFromURN(urn *urnx.URN) (types.Resource, error) {
+func (e *Engine) NewResourceFromURN(urn *urnx.URN) (types.Resource, error) {
 	out := types.Resource{
 		Type: urn.ResourceType,
 		ID:   urn.ResourceID,
@@ -87,12 +81,12 @@ func (e *MockEngine) NewResourceFromURN(urn *urnx.URN) (types.Resource, error) {
 }
 
 // NewURNFromResource creates a new URN from the given resource.
-func (e *MockEngine) NewURNFromResource(res types.Resource) (*urnx.URN, error) {
+func (e *Engine) NewURNFromResource(res types.Resource) (*urnx.URN, error) {
 	return urnx.Build(e.Namespace, res.Type, res.ID)
 }
 
 // SubjectHasPermission returns nil to satisfy the Engine interface.
-func (e *MockEngine) SubjectHasPermission(ctx context.Context, subject types.Resource, action string, resource types.Resource, queryToken string) error {
+func (e *Engine) SubjectHasPermission(ctx context.Context, subject types.Resource, action string, resource types.Resource, queryToken string) error {
 	e.Called()
 
 	return nil

--- a/internal/query/service.go
+++ b/internal/query/service.go
@@ -1,16 +1,36 @@
 package query
 
-import "github.com/authzed/authzed-go/v1"
+import (
+	"context"
+
+	"github.com/authzed/authzed-go/v1"
+	"go.infratographer.com/x/urnx"
+
+	"go.infratographer.com/permissions-api/internal/types"
+)
 
 // Engine represents a client for making permissions queries.
-type Engine struct {
+type Engine interface {
+	AssignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) (string, error)
+	CreateRelationships(ctx context.Context, rels []types.Relationship) (string, error)
+	CreateRole(ctx context.Context, res types.Resource, actions []string) (types.Role, string, error)
+	ListAssignments(ctx context.Context, role types.Role, queryToken string) ([]types.Resource, error)
+	ListRelationships(ctx context.Context, resource types.Resource, queryToken string) ([]types.Relationship, error)
+	ListRoles(ctx context.Context, resource types.Resource, queryToken string) ([]types.Role, error)
+	DeleteRelationships(ctx context.Context, resource types.Resource) (string, error)
+	NewResourceFromURN(urn *urnx.URN) (types.Resource, error)
+	NewURNFromResource(res types.Resource) (*urnx.URN, error)
+	SubjectHasPermission(ctx context.Context, subject types.Resource, action string, resource types.Resource, queryToken string) error
+}
+
+type engine struct {
 	namespace string
 	client    *authzed.Client
 }
 
 // NewEngine returns a new client for making permissions queries.
-func NewEngine(namespace string, client *authzed.Client) *Engine {
-	return &Engine{
+func NewEngine(namespace string, client *authzed.Client) Engine {
+	return &engine{
 		namespace: namespace,
 		client:    client,
 	}

--- a/internal/query/tenants_test.go
+++ b/internal/query/tenants_test.go
@@ -16,7 +16,7 @@ import (
 	"go.infratographer.com/x/urnx"
 )
 
-func testEngine(ctx context.Context, t *testing.T, namespace string) *Engine {
+func testEngine(ctx context.Context, t *testing.T, namespace string) Engine {
 	config := spicedbx.Config{
 		Endpoint: "spicedb:50051",
 		Key:      "infradev",

--- a/internal/testingx/testing.go
+++ b/internal/testingx/testing.go
@@ -19,7 +19,7 @@ type TestResult[U any] struct {
 type TestCase[T, U any] struct {
 	Name      string
 	Input     T
-	SetupFn   func(context.Context) context.Context
+	SetupFn   func(context.Context, *testing.T) context.Context
 	CheckFn   func(context.Context, *testing.T, TestResult[U])
 	CleanupFn func(context.Context)
 }
@@ -36,7 +36,7 @@ func RunTests[T, U any](ctx context.Context, t *testing.T, cases []TestCase[T, U
 			ctx := ctx
 
 			if testCase.SetupFn != nil {
-				ctx = testCase.SetupFn(ctx)
+				ctx = testCase.SetupFn(ctx, t)
 			}
 
 			if testCase.CleanupFn != nil {


### PR DESCRIPTION
All resource lifecycle events are expected to flow to permissions-api through NATS. This PR introduces a NATS JetStream consumer based on a prior implementation of NATS worker logic in permissions-api that listens for events on resource types.

Additionally, this commit adds NATS-specific development tooling and updates the Makefile to perform some of the tool fetching/building logic that was previously in the dev container Dockerfile to reduce build times in CI.

[rm-doc]: https://github.com/infratographer/permissions-api/blob/11259e74d320bf8f8030133244160fe0db21e34b/docs/resource_management.md