### PR TITLE
correct service monitor port name

### DIFF
--- a/chart/permissions-api/templates/serviceMonitor.yaml
+++ b/chart/permissions-api/templates/serviceMonitor.yaml
@@ -9,5 +9,5 @@ spec:
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
   endpoints:
-    - port: web
+    - port: http
 {{- end }}


### PR DESCRIPTION
Correct bad copy paste fail copying the incorrect port name.