### PR TITLE
Fix relation validation

### DIFF
--- a/internal/iapl/default.go
+++ b/internal/iapl/default.go
@@ -1,8 +1,8 @@
 package iapl
 
-// DefaultPolicy generates the default policy for permissions-api.
-func DefaultPolicy() Policy {
-	policyDocument := PolicyDocument{
+// DefaultPolicyDocument returns the default policy document for permissions-api.
+func DefaultPolicyDocument() PolicyDocument {
+	return PolicyDocument{
 		ResourceTypes: []ResourceType{
 			{
 				Name:     "role",
@@ -204,6 +204,11 @@ func DefaultPolicy() Policy {
 			},
 		},
 	}
+}
+
+// DefaultPolicy generates the default policy for permissions-api.
+func DefaultPolicy() Policy {
+	policyDocument := DefaultPolicyDocument()
 
 	policy := NewPolicy(policyDocument)
 	if err := policy.Validate(); err != nil {

--- a/internal/query/relations.go
+++ b/internal/query/relations.go
@@ -40,12 +40,12 @@ func (e *engine) validateRelationship(rel types.Relationship) error {
 		return err
 	}
 
-	for _, typeRel := range subjType.Relationships {
+	for _, typeRel := range resType.Relationships {
 		// If we find a relation with a name and type that matches our relationship,
 		// return
 		if rel.Relation == typeRel.Relation {
 			for _, typeName := range typeRel.Types {
-				if resType.Name == typeName {
+				if subjType.Name == typeName {
 					return nil
 				}
 			}


### PR DESCRIPTION
Previously we were checking if the destination resource had a relation
rather than the targeted resource having a relation to the destination.

This resulted in the following not working:

```yaml
resourcetypes:
  - name: folder
    relationships:
      - relation: parent
        targettypenames:
          - folder
  - name: file
    relationships:
      - relation: parent
        targettypenames:
          - folder
```

When creating a relationship previously, relating a folder to a parent
folder would work since they happen to have the same resource type.
However relating a file to a parent folder would fail due to us checking
if folder has a parent relationship type name for file.