### PR TITLE
worker volumes also need events volume support

### DIFF
--- a/chart/permissions-api/templates/_helpers.tpl
+++ b/chart/permissions-api/templates/_helpers.tpl
@@ -4,7 +4,7 @@
 {{- .Values.config.server.port | default 8080 }}
 {{- end }}
 
-{{- define "permapi.volumes" }}
+{{- define "permapi.server.volumes" }}
 {{- if or .Values.config.spicedb.caSecretName .Values.config.spicedb.policyConfigMapName }}
 {{- with .Values.config.spicedb.caSecretName }}
 - name: spicedb-ca
@@ -21,11 +21,52 @@
 {{- end }}
 {{- end }}
 
-{{- define "permapi.volumeMounts" }}
+{{- define "permapi.server.volumeMounts" }}
 {{- if or .Values.config.spicedb.caSecretName .Values.config.spicedb.policyConfigMapName }}
 {{- if .Values.config.spicedb.caSecretName }}
 - name: spicedb-ca
   mountPath: /etc/ssl/spicedb/
+{{- end }}
+{{- if .Values.config.spicedb.policyConfigMapName }}
+- name: policy-file
+  mountPath: /policy
+{{- end }}
+{{- else -}}
+[]
+{{- end }}
+{{- end }}
+
+{{- define "permapi.worker.volumes" }}
+{{- if or .Values.config.spicedb.caSecretName .Values.config.spicedb.policyConfigMapName .Values.config.events.nats.credsSecretName }}
+{{- with .Values.config.spicedb.caSecretName }}
+- name: spicedb-ca
+  secret:
+    secretName: {{ . }}
+{{- end }}
+{{- with .Values.config.events.nats.credsSecretName }}
+- name: nats-creds
+  secret:
+    secretName: {{ . }}
+{{- end }}
+{{- with .Values.config.spicedb.policyConfigMapName }}
+- name: policy-file
+  configMap:
+    name: {{ . }}
+{{- end }}
+{{- else -}}
+[]
+{{- end }}
+{{- end }}
+
+{{- define "permapi.worker.volumeMounts" }}
+{{- if or .Values.config.spicedb.caSecretName .Values.config.spicedb.policyConfigMapName .Values.config.events.nats.credsSecretName }}
+{{- if .Values.config.spicedb.caSecretName }}
+- name: spicedb-ca
+  mountPath: /etc/ssl/spicedb/
+{{- end }}
+{{- if .Values.config.events.nats.credsSecretName }}
+- name: nats-creds
+  mountPath: /nats
 {{- end }}
 {{- if .Values.config.spicedb.policyConfigMapName }}
 - name: policy-file

--- a/chart/permissions-api/templates/deployment-server.yaml
+++ b/chart/permissions-api/templates/deployment-server.yaml
@@ -125,7 +125,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          volumeMounts: {{ include "permapi.volumeMounts" . | nindent 12 }}
+          volumeMounts: {{ include "permapi.server.volumeMounts" . | nindent 12 }}
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -138,4 +138,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      volumes: {{ include "permapi.volumes" . | nindent 8 }}
+      volumes: {{ include "permapi.server.volumes" . | nindent 8 }}

--- a/chart/permissions-api/templates/deployment-worker.yaml
+++ b/chart/permissions-api/templates/deployment-worker.yaml
@@ -147,7 +147,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          volumeMounts: {{ include "permapi.volumeMounts" . | nindent 12 }}
+          volumeMounts: {{ include "permapi.worker.volumeMounts" . | nindent 12 }}
       {{- with .Values.deployment.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -160,4 +160,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      volumes: {{ include "permapi.volumes" . | nindent 8 }}
+      volumes: {{ include "permapi.worker.volumes" . | nindent 8 }}


### PR DESCRIPTION
The worker was missing attaching the credsSecretName volume to the pod. This adds that.