### PR TITLE
Correct event relationships

### DIFF
--- a/chart/permissions-api/templates/deployment-worker.yaml
+++ b/chart/permissions-api/templates/deployment-worker.yaml
@@ -76,7 +76,7 @@ spec:
           {{- end }}
           {{- if .Values.config.events.nats.token }}
             - name: PERMISSIONSAPI_EVENTS_SUBSCRIBER_NATS_TOKEN
-              value: "{{ .Values.config.events.token }}"
+              value: "{{ .Values.config.events.nats.token }}"
           {{- end }}
           {{- if .Values.config.oidc.issuer }}
           {{- with .Values.config.oidc.audience }}

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -75,9 +75,13 @@ func worker(ctx context.Context, cfg *config.AppConfig) {
 		}
 	}
 
-	if err := subscriber.Listen(); err != nil {
-		logger.Fatalw("error listening for events", "error", err)
-	}
+	logger.Info("Listening for events")
+
+	go func() {
+		if err := subscriber.Listen(); err != nil {
+			logger.Fatalw("error listening for events", "error", err)
+		}
+	}()
 
 	// Wait until we're told to stop
 	sig := <-sigCh

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -62,9 +62,9 @@ func worker(ctx context.Context, cfg *config.AppConfig) {
 		logger.Fatalw("invalid spicedb policy", "error", err)
 	}
 
-	engine := query.NewEngine("infratographer", spiceClient, query.WithPolicy(policy))
+	engine := query.NewEngine("infratographer", spiceClient, query.WithPolicy(policy), query.WithLogger(logger))
 
-	subscriber, err := pubsub.NewSubscriber(ctx, cfg.Events.Subscriber, engine)
+	subscriber, err := pubsub.NewSubscriber(ctx, cfg.Events.Subscriber, engine, pubsub.WithLogger(logger))
 	if err != nil {
 		logger.Fatalw("unable to initialize subscriber", "error", err)
 	}

--- a/internal/pubsub/subscriber.go
+++ b/internal/pubsub/subscriber.go
@@ -81,6 +81,8 @@ func (s *Subscriber) Subscribe(topic string) error {
 
 	s.changeChannels = append(s.changeChannels, msgChan)
 
+	s.logger.Infof("Subscribing to topic %s", topic)
+
 	return nil
 }
 
@@ -190,9 +192,7 @@ func (s *Subscriber) createRelationships(ctx context.Context, msg *message.Messa
 	// Attempt to create the relationships in SpiceDB. If this fails, nak the message for reprocessing
 	_, err := s.qe.CreateRelationships(ctx, relationships)
 	if err != nil {
-		s.logger.Errorw("error creating relationships - will reprocess", "error", err.Error())
-
-		return err
+		s.logger.Errorw("error creating relationships - will not reprocess", "error", err.Error())
 	}
 
 	return nil
@@ -201,9 +201,7 @@ func (s *Subscriber) createRelationships(ctx context.Context, msg *message.Messa
 func (s *Subscriber) deleteRelationships(ctx context.Context, msg *message.Message, resource types.Resource) error {
 	_, err := s.qe.DeleteRelationships(ctx, resource)
 	if err != nil {
-		s.logger.Errorw("error deleting relationships - will reprocess", "error", err.Error())
-
-		return err
+		s.logger.Errorw("error deleting relationships - will not reprocess", "error", err.Error())
 	}
 
 	return nil

--- a/internal/pubsub/subscriber_test.go
+++ b/internal/pubsub/subscriber_test.go
@@ -151,7 +151,7 @@ func TestNATS(t *testing.T) {
 				return context.WithValue(ctx, contextKeyEngine, &engine)
 			},
 			CheckFn: func(ctx context.Context, t *testing.T, result testingx.TestResult[*Subscriber]) {
-				require.ErrorIs(t, result.Err, eventtools.ErrNack)
+				require.NoError(t, result.Err)
 			},
 		},
 		{

--- a/internal/query/errors.go
+++ b/internal/query/errors.go
@@ -9,4 +9,13 @@ var (
 
 	// ErrInvalidReference represents an error condition where a given SpiceDB object reference is for some reason invalid.
 	ErrInvalidReference = errors.New("invalid reference")
+
+	// ErrInvalidNamespace represents an error when the id prefix is not found in the resource schema
+	ErrInvalidNamespace = errors.New("invalid namespace")
+
+	// ErrInvalidType represents an error when a resource type is not found in the resource schema
+	ErrInvalidType = errors.New("invalid type")
+
+	// ErrInvalidRelationship represents an error when no matching relationship was found
+	ErrInvalidRelationship = errors.New("invalid relationship")
 )

--- a/internal/query/mock/mock.go
+++ b/internal/query/mock/mock.go
@@ -104,6 +104,21 @@ func (e *Engine) NewResourceFromID(id gidx.PrefixedID) (types.Resource, error) {
 	return out, nil
 }
 
+// GetResourceType returns the resource type by name
+func (e *Engine) GetResourceType(name string) *types.ResourceType {
+	if e.schema == nil {
+		e.schema = iapl.DefaultPolicy().Schema()
+	}
+
+	for _, resourceType := range e.schema {
+		if resourceType.Name == name {
+			return &resourceType
+		}
+	}
+
+	return nil
+}
+
 // SubjectHasPermission returns nil to satisfy the Engine interface.
 func (e *Engine) SubjectHasPermission(ctx context.Context, subject types.Resource, action string, resource types.Resource, queryToken string) error {
 	e.Called()

--- a/internal/query/relations_test.go
+++ b/internal/query/relations_test.go
@@ -224,7 +224,7 @@ func TestRelationships(t *testing.T) {
 				Subject:  parentRes,
 			},
 			CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[[]types.Relationship]) {
-				assert.ErrorIs(t, res.Err, errorInvalidRelationship)
+				assert.ErrorIs(t, res.Err, ErrInvalidRelationship)
 			},
 		},
 		{

--- a/policy.example.yaml
+++ b/policy.example.yaml
@@ -71,13 +71,13 @@ actionbindings:
       - relationshipaction:
           relation: parent
           actionname: loadbalancer_delete
-  - actionname: loadbalancer_create
+  - actionname: loadbalancer_get
     typename: loadbalancer
     conditions:
       - rolebinding: {}
       - relationshipaction:
           relation: owner
-          actionname: loadbalancer_create
+          actionname: loadbalancer_get
   - actionname: loadbalancer_update
     typename: loadbalancer
     conditions:


### PR DESCRIPTION
We were improperly building relationships setting the relation to the type of resource rather than the actual relation it had.

This now finds all the relations which are supported by the two resources and creates the appropriate relationships.