### PR TITLE
add worker http server for health checks

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,9 +3,7 @@ package cmd
 import (
 	"log"
 	"os"
-	"os/signal"
 	"strings"
-	"syscall"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -22,7 +20,6 @@ var (
 	cfgFile   string
 	logger    *zap.SugaredLogger
 	globalCfg *config.AppConfig
-	sigCh     chan os.Signal
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -60,10 +57,6 @@ func init() {
 	viperx.MustBindFlag(viper.GetViper(), "spicedb.prefix", rootCmd.PersistentFlags().Lookup("spicedb-prefix"))
 	rootCmd.PersistentFlags().String("spicedb-policy", "", "spicedb policy file")
 	viperx.MustBindFlag(viper.GetViper(), "spicedb.policyFile", rootCmd.PersistentFlags().Lookup("spicedb-policy"))
-
-	// Set up SIGINT/SIGTERM listener
-	sigCh = make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/internal/spicedbx/client.go
+++ b/internal/spicedbx/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/authzed-go/v1"
 	"github.com/authzed/grpcutil"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -61,9 +62,14 @@ func NewClient(cfg Config, enableTracing bool) (*authzed.Client, error) {
 	return authzed.NewClient(cfg.Endpoint, clientOpts...)
 }
 
-// Healthcheck does nothing :laughing:
+// Healthcheck reads the schema to check if the connection is working
 func Healthcheck(client *authzed.Client) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
+		_, err := client.ReadSchema(ctx, &v1.ReadSchemaRequest{}, grpc.WaitForReady(false))
+		if err != nil {
+			return err
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
Adds http server for worker so the chart can properly run health checks.

Additionally updates the health check for spicedb to read the schema for it's health check.