### PR TITLE
Check for otlpgrpc as tracing provider instead of otlp

### DIFF
--- a/chart/permissions-api/templates/deployment-server.yaml
+++ b/chart/permissions-api/templates/deployment-server.yaml
@@ -98,7 +98,7 @@ spec:
             - name: PERMISSIONSAPI_TRACING_JAEGER_PASSWORD
               value: "{{ .Values.config.tracing.jaeger.password }}"
             {{- end }}
-            {{- if eq .Values.config.tracing.provider "otlp" }}
+            {{- if eq .Values.config.tracing.provider "otlpgrpc" }}
             - name: PERMISSIONSAPI_TRACING_OTLP_ENDPOINT
               value: "{{ .Values.config.tracing.otlp.endpoint }}"
             - name: PERMISSIONSAPI_TRACING_OTLP_INSECURE

--- a/chart/permissions-api/templates/deployment-worker.yaml
+++ b/chart/permissions-api/templates/deployment-worker.yaml
@@ -120,7 +120,7 @@ spec:
             - name: PERMISSIONSAPI_TRACING_JAEGER_PASSWORD
               value: "{{ .Values.config.tracing.jaeger.password }}"
             {{- end }}
-            {{- if eq .Values.config.tracing.provider "otlp" }}
+            {{- if eq .Values.config.tracing.provider "otlpgrpc" }}
             - name: PERMISSIONSAPI_TRACING_OTLP_ENDPOINT
               value: "{{ .Values.config.tracing.otlp.endpoint }}"
             - name: PERMISSIONSAPI_TRACING_OTLP_INSECURE


### PR DESCRIPTION
otelx uses "otlpgrpc" as the value for gRPC-based OTLP tracing, not "otlp". This PR fixes the Helm templates for permissions-api to use the correct value.