### PR TITLE
ensure permissions checks are fully consistent

### DIFF
--- a/internal/api/permissions.go
+++ b/internal/api/permissions.go
@@ -59,7 +59,7 @@ func (r *Router) checkAction(c echo.Context) error {
 	}
 
 	// Check the permissions
-	err = r.engine.SubjectHasPermission(ctx, subjectResource, action, resource, "")
+	err = r.engine.SubjectHasPermission(ctx, subjectResource, action, resource)
 	if err != nil && errors.Is(err, query.ErrActionNotAssigned) {
 		msg := fmt.Sprintf("subject '%s' does not have permission to perform action '%s' on resource '%s'",
 			subject, action, resourceIDStr)

--- a/internal/query/mock/mock.go
+++ b/internal/query/mock/mock.go
@@ -139,7 +139,7 @@ func (e *Engine) GetResourceType(name string) *types.ResourceType {
 }
 
 // SubjectHasPermission returns nil to satisfy the Engine interface.
-func (e *Engine) SubjectHasPermission(ctx context.Context, subject types.Resource, action string, resource types.Resource, queryToken string) error {
+func (e *Engine) SubjectHasPermission(ctx context.Context, subject types.Resource, action string, resource types.Resource) error {
 	e.Called()
 
 	return nil

--- a/internal/query/relations_test.go
+++ b/internal/query/relations_test.go
@@ -523,7 +523,7 @@ func TestSubjectActions(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	queryToken, err := e.AssignSubjectRole(ctx, subjRes, role)
+	_, err = e.AssignSubjectRole(ctx, subjRes, role)
 	assert.NoError(t, err)
 
 	type testInput struct {
@@ -565,7 +565,7 @@ func TestSubjectActions(t *testing.T) {
 	}
 
 	testFn := func(ctx context.Context, input testInput) testingx.TestResult[any] {
-		err := e.SubjectHasPermission(ctx, subjRes, input.action, input.resource, queryToken)
+		err := e.SubjectHasPermission(ctx, subjRes, input.action, input.resource)
 
 		return testingx.TestResult[any]{
 			Err: err,

--- a/internal/query/service.go
+++ b/internal/query/service.go
@@ -25,7 +25,7 @@ type Engine interface {
 	DeleteRelationships(ctx context.Context, resource types.Resource) (string, error)
 	NewResourceFromID(id gidx.PrefixedID) (types.Resource, error)
 	GetResourceType(name string) *types.ResourceType
-	SubjectHasPermission(ctx context.Context, subject types.Resource, action string, resource types.Resource, queryToken string) error
+	SubjectHasPermission(ctx context.Context, subject types.Resource, action string, resource types.Resource) error
 }
 
 type engine struct {


### PR DESCRIPTION
spicedb has caching, this ensures that checks, check the latest state.