### PR TITLE
move chart to using a config file instead of env

### DIFF
--- a/chart/permissions-api/templates/_helpers.tpl
+++ b/chart/permissions-api/templates/_helpers.tpl
@@ -5,7 +5,9 @@
 {{- end }}
 
 {{- define "permapi.server.volumes" }}
-{{- if or .Values.config.spicedb.caSecretName .Values.config.spicedb.policyConfigMapName }}
+- name: app-config
+  configMap:
+    name: {{ include "common.names.name" . }}-server-config
 {{- with .Values.config.spicedb.caSecretName }}
 - name: spicedb-ca
   secret:
@@ -16,13 +18,11 @@
   configMap:
     name: {{ . }}
 {{- end }}
-{{- else -}}
-[]
-{{- end }}
 {{- end }}
 
 {{- define "permapi.server.volumeMounts" }}
-{{- if or .Values.config.spicedb.caSecretName .Values.config.spicedb.policyConfigMapName }}
+- name: app-config
+  mountPath: /config/
 {{- if .Values.config.spicedb.caSecretName }}
 - name: spicedb-ca
   mountPath: /etc/ssl/spicedb/
@@ -31,13 +31,12 @@
 - name: policy-file
   mountPath: /policy
 {{- end }}
-{{- else -}}
-[]
-{{- end }}
 {{- end }}
 
 {{- define "permapi.worker.volumes" }}
-{{- if or .Values.config.spicedb.caSecretName .Values.config.spicedb.policyConfigMapName .Values.config.events.nats.credsSecretName }}
+- name: app-config
+  configMap:
+    name: {{ include "common.names.name" . }}-worker-config
 {{- with .Values.config.spicedb.caSecretName }}
 - name: spicedb-ca
   secret:
@@ -53,13 +52,11 @@
   configMap:
     name: {{ . }}
 {{- end }}
-{{- else -}}
-[]
-{{- end }}
 {{- end }}
 
 {{- define "permapi.worker.volumeMounts" }}
-{{- if or .Values.config.spicedb.caSecretName .Values.config.spicedb.policyConfigMapName .Values.config.events.nats.credsSecretName }}
+- name: app-config
+  mountPath: /config/
 {{- if .Values.config.spicedb.caSecretName }}
 - name: spicedb-ca
   mountPath: /etc/ssl/spicedb/
@@ -71,8 +68,5 @@
 {{- if .Values.config.spicedb.policyConfigMapName }}
 - name: policy-file
   mountPath: /policy
-{{- end }}
-{{- else -}}
-[]
 {{- end }}
 {{- end }}

--- a/chart/permissions-api/templates/config-server.yaml
+++ b/chart/permissions-api/templates/config-server.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.name" . }}-server-config
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    service: server
+data:
+  config.yaml: |
+    {{- pick .Values.config "server" "oidc" "spicedb" "tracing" | toYaml | nindent 4 }}

--- a/chart/permissions-api/templates/config-worker.yaml
+++ b/chart/permissions-api/templates/config-worker.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "common.names.name" . }}-worker-config
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: '-1'
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    service: worker
+data:
+  config.yaml: |
+    {{- pick .Values.config "server" "events" "oidc" "spicedb" "tracing" | toYaml | nindent 4 }}

--- a/chart/permissions-api/templates/deployment-server.yaml
+++ b/chart/permissions-api/templates/deployment-server.yaml
@@ -47,64 +47,20 @@ spec:
         - name: {{ include "common.names.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - server
+            - --config
+            - /config/config.yaml
           env:
             - name: PERMISSIONSAPI_SERVER_LISTEN
               value: ":{{ include "permapi.listenPort" . }}"
-            - name: PERMISSIONSAPI_SERVER_SHUTDOWN_GRACE_PERIOD
-              value: "{{ .Values.config.server.shutdownGracePeriod }}"
-          {{- with .Values.config.server.trustedProxies }}
-            - name: PERMISSIONSAPI_SERVER_TRUSTED_PROXIES
-              value: "{{ join " " . }}"
-          {{- end }}
-          {{- if .Values.config.oidc.issuer }}
-          {{- with .Values.config.oidc.audience }}
-            - name: PERMISSIONSAPI_OIDC_AUDIENCE
-              value: "{{ . }}"
-          {{- end }}
-          {{- with .Values.config.oidc.issuer }}
-            - name: PERMISSIONSAPI_OIDC_ISSUER
-              value: "{{ . }}"
-          {{- end }}
-          {{- with .Values.config.oidc.refreshTimeout }}
-            - name: PERMISSIONSAPI_OIDC_REFRESH_TIMEOUT
-              value: "{{ . }}"
-          {{- end }}
-          {{- end }}
-            - name: PERMISSIONSAPI_SPICEDB_ENDPOINT
-              value: "{{ .Values.config.spicedb.endpoint }}"
-            - name: PERMISSIONSAPI_SPICEDB_INSECURE
-              value: "{{ .Values.config.spicedb.insecure }}"
-            - name: PERMISSIONSAPI_SPICEDB_VERIFYCA
-              value: "{{ .Values.config.spicedb.verifyCA }}"
           {{- if .Values.config.spicedb.policyConfigMapName }}
             - name: PERMISSIONSAPI_SPICEDB_POLICYFILE
               value: /policy/policy.yaml
           {{- end }}
-            - name: PERMISSIONSAPI_TRACING_ENABLED
-              value: "{{ .Values.config.tracing.enabled }}"
-            - name: PERMISSIONSAPI_TRACING_PROVIDER
-              value: "{{ .Values.config.tracing.provider }}"
-            - name: PERMISSIONSAPI_TRACING_ENVIRONMENT
-              value: "{{ .Values.config.tracing.environment }}"
             {{- if .Values.config.spicedb.caSecretName }}
             - name: SSL_CERT_DIR
               value: "/etc/ssl/spicedb"
-            {{- end }}
-            {{- if eq .Values.config.tracing.provider "jaeger" }}
-            - name: PERMISSIONSAPI_TRACING_JAEGER_ENDPOINT
-              value: "{{ .Values.config.tracing.jaeger.endpoint }}"
-            - name: PERMISSIONSAPI_TRACING_JAEGER_USER
-              value: "{{ .Values.config.tracing.jaeger.user }}"
-            - name: PERMISSIONSAPI_TRACING_JAEGER_PASSWORD
-              value: "{{ .Values.config.tracing.jaeger.password }}"
-            {{- end }}
-            {{- if eq .Values.config.tracing.provider "otlpgrpc" }}
-            - name: PERMISSIONSAPI_TRACING_OTLP_ENDPOINT
-              value: "{{ .Values.config.tracing.otlp.endpoint }}"
-            - name: PERMISSIONSAPI_TRACING_OTLP_INSECURE
-              value: "{{ .Values.config.tracing.otlp.insecure }}"
-            - name: PERMISSIONSAPI_TRACING_OTLP_CERTIFICATE
-              value: "{{ .Values.config.tracing.otlp.certificate }}"
             {{- end }}
           envFrom:
             - secretRef:

--- a/chart/permissions-api/templates/deployment-worker.yaml
+++ b/chart/permissions-api/templates/deployment-worker.yaml
@@ -49,45 +49,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - worker
+            - --config
+            - /config/config.yaml
           env:
             - name: PERMISSIONSAPI_SERVER_LISTEN
               value: ":{{ include "permapi.listenPort" . }}"
-            - name: PERMISSIONSAPI_SERVER_SHUTDOWN_GRACE_PERIOD
-              value: "{{ .Values.config.server.shutdownGracePeriod }}"
-          {{- with .Values.config.server.trustedProxies }}
-            - name: PERMISSIONSAPI_SERVER_TRUSTED_PROXIES
-              value: "{{ join " " . }}"
-          {{- end }}
-            - name: PERMISSIONSAPI_EVENTS_NATS_URL
-              value: "{{ .Values.config.events.nats.url }}"
-            - name: PERMISSIONSAPI_EVENTS_NATS_SUBSCRIBEPREFIX
-              value: "{{ .Values.config.events.nats.subscribePrefix }}"
-            - name: PERMISSIONSAPI_EVENTS_NATS_QUEUEGROUP
-              value: "{{ .Values.config.events.nats.queueGroup }}"
-            - name: PERMISSIONSAPI_EVENTS_NATS_SOURCE
-              value: "{{ .Values.config.events.nats.source }}"
-            - name: PERMISSIONSAPI_EVENTS_NATS_CONNECTTIMEOUT
-              value: "{{ .Values.config.events.nats.connectTimeout }}"
-            - name: PERMISSIONSAPI_EVENTS_NATS_SHUTDOWNTIMEOUT
-              value: "{{ .Values.config.events.nats.shutdownTimeout }}"
-            - name: PERMISSIONSAPI_EVENTS_NATS_SUBSCRIBERFETCHBATCHSIZE
-              value: "{{ .Values.config.events.nats.subscriberFetchBatchSize }}"
-            - name: PERMISSIONSAPI_EVENTS_NATS_SUBSCRIBERFETCHTIMEOUT
-              value: "{{ .Values.config.events.nats.subscriberFetchTimeout }}"
-            - name: PERMISSIONSAPI_EVENTS_NATS_SUBSCRIBERFETCHBACKOFF
-              value: "{{ .Values.config.events.nats.subscriberFetchBackoff }}"
-            - name: PERMISSIONSAPI_EVENTS_NATS_SUBSCRIBERNOACKEXPLICIT
-              value: "{{ .Values.config.events.nats.subscriberNoAckExplicit }}"
-            - name: PERMISSIONSAPI_EVENTS_NATS_SUBSCRIBERNOMANUALACK
-              value: "{{ .Values.config.events.nats.subscriberNoManualAck }}"
-            - name: PERMISSIONSAPI_EVENTS_NATS_SUBSCRIBERDELIVERYPOLICY
-              value: "{{ .Values.config.events.nats.subscriberDeliveryPolicy }}"
-            - name: PERMISSIONSAPI_EVENTS_NATS_SUBSCRIBERSTARTSEQUENCE
-              value: "{{ .Values.config.events.nats.subscriberStartSequence }}"
-          {{- with .Values.config.events.topics }}
-            - name: PERMISSIONSAPI_EVENTS_TOPICS
-              value: "{{ join " " . }}"
-          {{- end }}
           {{- if .Values.config.events.nats.tokenSecretName }}
             - name: PERMISSIONSAPI_EVENTS_NATS_TOKEN
               valueFrom:
@@ -95,59 +61,13 @@ spec:
                   name: {{ .Values.config.events.nats.tokenSecretName }}
                   key: token
           {{- end }}
-          {{- if .Values.config.events.nats.credsSecretName }}
-            - name: PERMISSIONSAPI_EVENTS_NATS_CREDSFILE
-              value: "{{ .Values.config.events.nats.credsFile }}"
-          {{- end }}
-          {{- if .Values.config.oidc.issuer }}
-          {{- with .Values.config.oidc.audience }}
-            - name: PERMISSIONSAPI_OIDC_AUDIENCE
-              value: "{{ . }}"
-          {{- end }}
-          {{- with .Values.config.oidc.issuer }}
-            - name: PERMISSIONSAPI_OIDC_ISSUER
-              value: "{{ . }}"
-          {{- end }}
-          {{- with .Values.config.oidc.refreshTimeout }}
-            - name: PERMISSIONSAPI_OIDC_REFRESH_TIMEOUT
-              value: "{{ . }}"
-          {{- end }}
-          {{- end }}
-            - name: PERMISSIONSAPI_SPICEDB_ENDPOINT
-              value: "{{ .Values.config.spicedb.endpoint }}"
-            - name: PERMISSIONSAPI_SPICEDB_INSECURE
-              value: "{{ .Values.config.spicedb.insecure }}"
-            - name: PERMISSIONSAPI_SPICEDB_VERIFYCA
-              value: "{{ .Values.config.spicedb.verifyCA }}"
           {{- if .Values.config.spicedb.policyConfigMapName }}
             - name: PERMISSIONSAPI_SPICEDB_POLICYFILE
               value: /policy/policy.yaml
           {{- end }}
-            - name: PERMISSIONSAPI_TRACING_ENABLED
-              value: "{{ .Values.config.tracing.enabled }}"
-            - name: PERMISSIONSAPI_TRACING_PROVIDER
-              value: "{{ .Values.config.tracing.provider }}"
-            - name: PERMISSIONSAPI_TRACING_ENVIRONMENT
-              value: "{{ .Values.config.tracing.environment }}"
             {{- if .Values.config.spicedb.caSecretName }}
             - name: SSL_CERT_DIR
               value: "/etc/ssl/spicedb"
-            {{- end }}
-            {{- if eq .Values.config.tracing.provider "jaeger" }}
-            - name: PERMISSIONSAPI_TRACING_JAEGER_ENDPOINT
-              value: "{{ .Values.config.tracing.jaeger.endpoint }}"
-            - name: PERMISSIONSAPI_TRACING_JAEGER_USER
-              value: "{{ .Values.config.tracing.jaeger.user }}"
-            - name: PERMISSIONSAPI_TRACING_JAEGER_PASSWORD
-              value: "{{ .Values.config.tracing.jaeger.password }}"
-            {{- end }}
-            {{- if eq .Values.config.tracing.provider "otlpgrpc" }}
-            - name: PERMISSIONSAPI_TRACING_OTLP_ENDPOINT
-              value: "{{ .Values.config.tracing.otlp.endpoint }}"
-            - name: PERMISSIONSAPI_TRACING_OTLP_INSECURE
-              value: "{{ .Values.config.tracing.otlp.insecure }}"
-            - name: PERMISSIONSAPI_TRACING_OTLP_CERTIFICATE
-              value: "{{ .Values.config.tracing.otlp.certificate }}"
             {{- end }}
           envFrom:
             - secretRef:


### PR DESCRIPTION
After updating event topics to be pulled from the config file, viper doesn't handle environment slices automatically so instead it stores a single string with all topics.

Changing to using a config file simplifies config changes and ensures the correct values are read.