### PR TITLE
Make worker image configurable

### DIFF
--- a/chart/permissions-api/templates/deployment-worker.yaml
+++ b/chart/permissions-api/templates/deployment-worker.yaml
@@ -45,8 +45,8 @@ spec:
       {{- end }}
       containers:
         - name: {{ include "common.names.name" . }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.workerImage.repository }}:{{ .Values.workerImage.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.workerImage.pullPolicy }}
           args:
             - worker
             - --config

--- a/chart/permissions-api/values.yaml
+++ b/chart/permissions-api/values.yaml
@@ -6,6 +6,14 @@ image:
   # tag is the image tag to use. Defaults to the chart's app version
   tag: ""
 
+workerImage:
+  # repository is the image repository to pull the worker image from
+  repository: ghcr.io/infratographer/permissions-api
+  # pullPolicy is the image pull policy for the worker image
+  pullPolicy: IfNotPresent
+  # tag is the image tag to use. Defaults to the chart's app version
+  tag: ""
+
 config:
   server:
     # port is the port that the permissions-api container should listen on


### PR DESCRIPTION
This PR makes the worker image for permissions-api configurable separately from the API image.