### PR TITLE
Explicitly set ownership of /workspace in CI runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: devcontainers/ci@v0.3
         with:
           push: never
-          runCmd: 'whoami && id -u $(whoami) && ls -l /workspace && make ci'
+          runCmd: 'sudo chown -R vscode:vscode /workspace && make ci'
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Pre-build image and run make ci-build in dev container
         uses: devcontainers/ci@v0.3
         with:
+          noCache: true
           push: never
           runCmd: make ci
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,9 +20,8 @@ jobs:
       - name: Pre-build image and run make ci-build in dev container
         uses: devcontainers/ci@v0.3
         with:
-          noCache: true
           push: never
-          runCmd: make ci
+          runCmd: 'whoami && id -u $(whoami) && ls -l /workspace && make ci'
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
It appears that newer Ubuntu runners check out code as UID 1001, which breaks CI as the default `vscode` user in dev containers is UID 1000 (see https://github.com/devcontainers/ci/issues/257). This PR addresses that issue by explicitly running `sudo chown` to make the `vscode` user own `/workspace`.