### PR TITLE
Role permissions checks

### DIFF
--- a/cmd/createrole.go
+++ b/cmd/createrole.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.infratographer.com/permissions-api/internal/config"
+	"go.infratographer.com/permissions-api/internal/iapl"
+	"go.infratographer.com/permissions-api/internal/query"
+	"go.infratographer.com/permissions-api/internal/spicedbx"
+	"go.infratographer.com/x/gidx"
+	"go.infratographer.com/x/viperx"
+)
+
+const (
+	createRoleFlagSubject  = "subject"
+	createRoleFlagResource = "resource"
+	createRoleFlagActions  = "actions"
+)
+
+var (
+	createRoleCmd = &cobra.Command{
+		Use:   "create-role",
+		Short: "create role in SpiceDB directly",
+		Run: func(cmd *cobra.Command, args []string) {
+			createRole(cmd.Context(), globalCfg)
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(createRoleCmd)
+
+	flags := createRoleCmd.Flags()
+	flags.String(createRoleFlagSubject, "", "subject to assign to created role")
+	flags.StringSlice(createRoleFlagActions, []string{}, "actions to assign to created role")
+	flags.String(createRoleFlagResource, "", "resource to bind to created role")
+
+	v := viper.GetViper()
+
+	viperx.MustBindFlag(v, createRoleFlagSubject, flags.Lookup(createRoleFlagSubject))
+	viperx.MustBindFlag(v, createRoleFlagActions, flags.Lookup(createRoleFlagActions))
+	viperx.MustBindFlag(v, createRoleFlagResource, flags.Lookup(createRoleFlagResource))
+}
+
+func createRole(ctx context.Context, cfg *config.AppConfig) {
+	subjectIDStr := viper.GetString(createRoleFlagSubject)
+	actions := viper.GetStringSlice(createRoleFlagActions)
+	resourceIDStr := viper.GetString(createRoleFlagResource)
+
+	if subjectIDStr == "" || len(actions) == 0 || resourceIDStr == "" {
+		logger.Fatal("invalid config")
+	}
+
+	spiceClient, err := spicedbx.NewClient(cfg.SpiceDB, cfg.Tracing.Enabled)
+	if err != nil {
+		logger.Fatalw("unable to initialize spicedb client", "error", err)
+	}
+
+	var policy iapl.Policy
+
+	if cfg.SpiceDB.PolicyFile != "" {
+		policy, err = iapl.NewPolicyFromFile(cfg.SpiceDB.PolicyFile)
+		if err != nil {
+			logger.Fatalw("unable to load new policy from schema file", "policy_file", cfg.SpiceDB.PolicyFile, "error", err)
+		}
+	} else {
+		logger.Warn("no spicedb policy file defined, using default policy")
+
+		policy = iapl.DefaultPolicy()
+	}
+
+	if err = policy.Validate(); err != nil {
+		logger.Fatalw("invalid spicedb policy", "error", err)
+	}
+
+	resourceID, err := gidx.Parse(resourceIDStr)
+	if err != nil {
+		logger.Fatalw("error parsing resource ID", "error", err)
+	}
+
+	subjectID, err := gidx.Parse(subjectIDStr)
+	if err != nil {
+		logger.Fatalw("error parsing subject ID", "error", err)
+	}
+
+	engine := query.NewEngine("infratographer", spiceClient, query.WithPolicy(policy), query.WithLogger(logger))
+
+	resource, err := engine.NewResourceFromID(resourceID)
+	if err != nil {
+		logger.Fatalw("error creating resource", "error", err)
+	}
+
+	subjectResource, err := engine.NewResourceFromID(subjectID)
+	if err != nil {
+		logger.Fatalw("error creating subject resource", "error", err)
+	}
+
+	role, _, err := engine.CreateRole(ctx, resource, actions)
+	if err != nil {
+		logger.Fatalw("error creating role", "error", err)
+	}
+
+	_, err = engine.AssignSubjectRole(ctx, subjectResource, role)
+	if err != nil {
+		logger.Fatalw("error creating role", "error", err)
+	}
+
+	logger.Infow("role successfully created", "role_id", role.ID)
+}

--- a/internal/api/permissions.go
+++ b/internal/api/permissions.go
@@ -67,28 +67,36 @@ func (r *Router) checkAction(c echo.Context) error {
 	}
 
 	// Subject validation
-	subject, err := currentSubject(c)
+	subjectResource, err := r.currentSubject(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "failed to get the subject").SetInternal(err)
-	}
-
-	subjectResource, err := r.engine.NewResourceFromID(subject)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "error processing subject ID").SetInternal(err)
+		return err
 	}
 
 	// Check the permissions
-	err = r.engine.SubjectHasPermission(ctx, subjectResource, action, resource)
-	if err != nil && errors.Is(err, query.ErrActionNotAssigned) {
-		msg := fmt.Sprintf("subject '%s' does not have permission to perform action '%s' on resource '%s'",
-			subject, action, resourceIDStr)
-
-		return echo.NewHTTPError(http.StatusForbidden, msg).SetInternal(err)
-	} else if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "an error occurred checking permissions").SetInternal(err)
+	if err := r.checkActionWithResponse(ctx, subjectResource, action, resource); err != nil {
+		return err
 	}
 
 	return c.JSON(http.StatusOK, echo.Map{})
+}
+
+func (r *Router) checkActionWithResponse(ctx context.Context, subjectResource types.Resource, action string, resource types.Resource) error {
+	err := r.engine.SubjectHasPermission(ctx, subjectResource, action, resource)
+	switch {
+	case errors.Is(err, query.ErrActionNotAssigned):
+		msg := fmt.Sprintf(
+			"subject '%s' does not have permission to perform action '%s' on resource '%s'",
+			subjectResource.ID.String(),
+			action,
+			resource.ID.String(),
+		)
+
+		return echo.NewHTTPError(http.StatusForbidden, msg).SetInternal(err)
+	case err != nil:
+		return echo.NewHTTPError(http.StatusInternalServerError, "an error occurred checking permissions").SetInternal(err)
+	default:
+		return nil
+	}
 }
 
 type checkPermissionsRequest struct {
@@ -124,14 +132,9 @@ func (r *Router) checkAllActions(c echo.Context) error {
 	defer span.End()
 
 	// Subject validation
-	subject, err := currentSubject(c)
+	subjectResource, err := r.currentSubject(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "failed to get the subject").SetInternal(err)
-	}
-
-	subjectResource, err := r.engine.NewResourceFromID(subject)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "error processing subject ID").SetInternal(err)
+		return err
 	}
 
 	var reqBody checkPermissionsRequest
@@ -223,8 +226,13 @@ func (r *Router) checkAllActions(c echo.Context) error {
 		case result := <-resultsCh:
 			if result.Error != nil {
 				if errors.Is(result.Error, query.ErrActionNotAssigned) {
-					err := fmt.Errorf("%w: subject '%s' does not have permission to perform action '%s' on resource '%s'",
-						ErrAccessDenied, subject, result.Request.Action, result.Request.Resource.ID.String())
+					err := fmt.Errorf(
+						"%w: subject '%s' does not have permission to perform action '%s' on resource '%s'",
+						ErrAccessDenied,
+						subjectResource.ID,
+						result.Request.Action,
+						result.Request.Resource.ID,
+					)
 
 					unauthorizedErrors++
 
@@ -254,7 +262,10 @@ func (r *Router) checkAllActions(c echo.Context) error {
 	}
 
 	if unauthorizedErrors != 0 {
-		msg := fmt.Sprintf("subject '%s' does not have permission to the requested resource actions", subject)
+		msg := fmt.Sprintf(
+			"subject '%s' does not have permission to the requested resource actions",
+			subjectResource.ID,
+		)
 
 		return echo.NewHTTPError(http.StatusForbidden, msg).SetInternal(multierr.Combine(allErrors...))
 	}

--- a/internal/api/permissions.go
+++ b/internal/api/permissions.go
@@ -82,6 +82,7 @@ func (r *Router) checkAction(c echo.Context) error {
 
 func (r *Router) checkActionWithResponse(ctx context.Context, subjectResource types.Resource, action string, resource types.Resource) error {
 	err := r.engine.SubjectHasPermission(ctx, subjectResource, action, resource)
+
 	switch {
 	case errors.Is(err, query.ErrActionNotAssigned):
 		msg := fmt.Sprintf(

--- a/internal/api/roles.go
+++ b/internal/api/roles.go
@@ -11,6 +11,10 @@ import (
 
 const (
 	actionRoleCreate = "role_create"
+	actionRoleGet    = "role_get"
+	actionRoleList   = "role_list"
+	actionRoleUpdate = "role_update"
+	actionRoleDelete = "role_delete"
 )
 
 func (r *Router) roleCreate(c echo.Context) error {
@@ -69,9 +73,18 @@ func (r *Router) roleGet(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "error getting resource").SetInternal(err)
 	}
 
+	subjectResource, err := r.currentSubject(c)
+	if err != nil {
+		return err
+	}
+
 	roleResource, err := r.engine.NewResourceFromID(roleResourceID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "error getting resource").SetInternal(err)
+	}
+
+	if err := r.checkActionWithResponse(ctx, subjectResource, actionRoleGet, roleResource); err != nil {
+		return err
 	}
 
 	role, err := r.engine.GetRole(ctx, roleResource, "")
@@ -98,9 +111,18 @@ func (r *Router) rolesList(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "error parsing resource ID").SetInternal(err)
 	}
 
+	subjectResource, err := r.currentSubject(c)
+	if err != nil {
+		return err
+	}
+
 	resource, err := r.engine.NewResourceFromID(resourceID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "error creating resource").SetInternal(err)
+	}
+
+	if err := r.checkActionWithResponse(ctx, subjectResource, actionRoleList, resource); err != nil {
+		return err
 	}
 
 	roles, err := r.engine.ListRoles(ctx, resource, "")
@@ -135,9 +157,18 @@ func (r *Router) roleDelete(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "error deleting resource").SetInternal(err)
 	}
 
+	subjectResource, err := r.currentSubject(c)
+	if err != nil {
+		return err
+	}
+
 	roleResource, err := r.engine.NewResourceFromID(roleResourceID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "error deleting resource").SetInternal(err)
+	}
+
+	if err := r.checkActionWithResponse(ctx, subjectResource, actionRoleDelete, roleResource); err != nil {
+		return err
 	}
 
 	_, err = r.engine.DeleteRole(ctx, roleResource, "")
@@ -163,9 +194,18 @@ func (r *Router) roleGetResource(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "error getting resource").SetInternal(err)
 	}
 
+	subjectResource, err := r.currentSubject(c)
+	if err != nil {
+		return err
+	}
+
 	roleResource, err := r.engine.NewResourceFromID(roleResourceID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "error getting resource").SetInternal(err)
+	}
+
+	if err := r.checkActionWithResponse(ctx, subjectResource, actionRoleGet, roleResource); err != nil {
+		return err
 	}
 
 	resource, err := r.engine.GetRoleResource(ctx, roleResource, "")

--- a/permissions-api.example.yaml
+++ b/permissions-api.example.yaml
@@ -1,3 +1,4 @@
 oidc:
   issuer: http://mock-oauth2-server:8081/default
-
+spicedb:
+  policyFile: /workspace/policy.example.yaml

--- a/policy.example.yaml
+++ b/policy.example.yaml
@@ -30,12 +30,20 @@ unions:
     resourcetypenames:
       - tenant
 actions:
+  - name: role_create
   - name: loadbalancer_create
   - name: loadbalancer_get
   - name: loadbalancer_list
   - name: loadbalancer_update
   - name: loadbalancer_delete
 actionbindings:
+  - actionname: role_create
+    typename: resourceowner
+    conditions:
+      - rolebinding: {}
+      - relationshipaction:
+          relation: parent
+          actionname: role_create
   - actionname: loadbalancer_create
     typename: resourceowner
     conditions:

--- a/policy.example.yaml
+++ b/policy.example.yaml
@@ -31,6 +31,10 @@ unions:
       - tenant
 actions:
   - name: role_create
+  - name: role_get
+  - name: role_list
+  - name: role_update
+  - name: role_delete
   - name: loadbalancer_create
   - name: loadbalancer_get
   - name: loadbalancer_list
@@ -44,6 +48,34 @@ actionbindings:
       - relationshipaction:
           relation: parent
           actionname: role_create
+  - actionname: role_get
+    typename: resourceowner
+    conditions:
+      - rolebinding: {}
+      - relationshipaction:
+          relation: parent
+          actionname: role_get
+  - actionname: role_list
+    typename: resourceowner
+    conditions:
+      - rolebinding: {}
+      - relationshipaction:
+          relation: parent
+          actionname: role_list
+  - actionname: role_update
+    typename: resourceowner
+    conditions:
+      - rolebinding: {}
+      - relationshipaction:
+          relation: parent
+          actionname: role_update
+  - actionname: role_delete
+    typename: resourceowner
+    conditions:
+      - rolebinding: {}
+      - relationshipaction:
+          relation: parent
+          actionname: role_delete
   - actionname: loadbalancer_create
     typename: resourceowner
     conditions:


### PR DESCRIPTION
This PR adds permissions checks for role management CRUD operations in the permissions-api API.

Because permissions checks are baked into the API (i.e., they cannot and should not be disabled), this PR also adds a command, `create-role`, which can be used to bootstrap the creation of roles that can allow a subject to create other roles. The conditions for actions like `role_create` are deliberately left out of permissions-api to allow operators to define their own policies.