### PR TITLE
Remove relationship create/delete handlers

### DIFF
--- a/internal/api/relationships.go
+++ b/internal/api/relationships.go
@@ -3,48 +3,11 @@ package api
 import (
 	"net/http"
 
-	"go.infratographer.com/permissions-api/internal/types"
-
 	"github.com/labstack/echo/v4"
 	"go.infratographer.com/x/gidx"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
-
-func (r *Router) buildRelationship(resource types.Resource, item createRelationshipItem) (types.Relationship, error) {
-	itemID, err := gidx.Parse(item.SubjectID)
-	if err != nil {
-		return types.Relationship{}, err
-	}
-
-	itemResource, err := r.engine.NewResourceFromID(itemID)
-	if err != nil {
-		return types.Relationship{}, err
-	}
-
-	out := types.Relationship{
-		Subject:  itemResource,
-		Relation: item.Relation,
-		Resource: resource,
-	}
-
-	return out, nil
-}
-
-func (r *Router) buildRelationships(subjResource types.Resource, items []createRelationshipItem) ([]types.Relationship, error) {
-	out := make([]types.Relationship, len(items))
-
-	for i, item := range items {
-		rel, err := r.buildRelationship(subjResource, item)
-		if err != nil {
-			return nil, err
-		}
-
-		out[i] = rel
-	}
-
-	return out, nil
-}
 
 func (r *Router) relationshipListFrom(c echo.Context) error {
 	resourceIDStr := c.Param("id")

--- a/internal/api/relationships.go
+++ b/internal/api/relationships.go
@@ -46,46 +46,6 @@ func (r *Router) buildRelationships(subjResource types.Resource, items []createR
 	return out, nil
 }
 
-func (r *Router) relationshipsCreate(c echo.Context) error {
-	resourceIDStr := c.Param("id")
-
-	ctx, span := tracer.Start(c.Request().Context(), "api.relationshipsCreate", trace.WithAttributes(attribute.String("id", resourceIDStr)))
-	defer span.End()
-
-	resourceID, err := gidx.Parse(resourceIDStr)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "error parsing resource ID").SetInternal(err)
-	}
-
-	var reqBody createRelationshipsRequest
-
-	err = c.Bind(&reqBody)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "error parsing request body").SetInternal(err)
-	}
-
-	resource, err := r.engine.NewResourceFromID(resourceID)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "error creating relationships").SetInternal(err)
-	}
-
-	rels, err := r.buildRelationships(resource, reqBody.Relationships)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "error creating relationships").SetInternal(err)
-	}
-
-	_, err = r.engine.CreateRelationships(ctx, rels)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "error creating relationships").SetInternal(err)
-	}
-
-	resp := createRelationshipsResponse{
-		Success: true,
-	}
-
-	return c.JSON(http.StatusCreated, resp)
-}
-
 func (r *Router) relationshipListFrom(c echo.Context) error {
 	resourceIDStr := c.Param("id")
 
@@ -158,55 +118,4 @@ func (r *Router) relationshipListTo(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, out)
-}
-
-func (r *Router) relationshipDelete(c echo.Context) error {
-	resourceIDStr := c.Param("id")
-
-	ctx, span := tracer.Start(c.Request().Context(), "api.relationshipsDelete", trace.WithAttributes(attribute.String("id", resourceIDStr)))
-	defer span.End()
-
-	resourceID, err := gidx.Parse(resourceIDStr)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "error parsing resource ID").SetInternal(err)
-	}
-
-	var reqBody deleteRelationshipRequest
-
-	err = c.Bind(&reqBody)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "error parsing request body").SetInternal(err)
-	}
-
-	resource, err := r.engine.NewResourceFromID(resourceID)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "error deleting relationship").SetInternal(err)
-	}
-
-	relatedResourceID, err := gidx.Parse(reqBody.SubjectID)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "error deleting relationship").SetInternal(err)
-	}
-
-	relatedResource, err := r.engine.NewResourceFromID(relatedResourceID)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "error deleting relationship").SetInternal(err)
-	}
-
-	relationship := types.Relationship{
-		Resource: resource,
-		Relation: reqBody.Relation,
-		Subject:  relatedResource,
-	}
-
-	_, err = r.engine.DeleteRelationships(ctx, relationship)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "error deleting relationship").SetInternal(err)
-	}
-
-	resp := deleteRelationshipsResponse{
-		Success: true,
-	}
-
-	return c.JSON(http.StatusOK, resp)
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -56,8 +56,6 @@ func (r *Router) Routes(rg *echo.Group) {
 
 		v1.POST("/resources/:id/roles", r.roleCreate)
 		v1.GET("/resources/:id/roles", r.rolesList)
-		v1.POST("/resources/:id/relationships", r.relationshipsCreate)
-		v1.DELETE("/resources/:id/relationships", r.relationshipDelete)
 		v1.GET("/resources/:id/relationships", r.relationshipListFrom)
 		v1.GET("/relationships/from/:id", r.relationshipListFrom)
 		v1.GET("/relationships/to/:id", r.relationshipListTo)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -25,28 +25,6 @@ type listRolesResponse struct {
 	Data []roleResponse `json:"data"`
 }
 
-type createRelationshipItem struct {
-	Relation  string `json:"relation" binding:"required"`
-	SubjectID string `json:"subject_id" binding:"required"`
-}
-
-type createRelationshipsRequest struct {
-	Relationships []createRelationshipItem `json:"relationships" binding:"required"`
-}
-
-type createRelationshipsResponse struct {
-	Success bool `json:"success"`
-}
-
-type deleteRelationshipRequest struct {
-	Relation  string `json:"relation" binding:"required"`
-	SubjectID string `json:"subject_id" binding:"required"`
-}
-
-type deleteRelationshipsResponse struct {
-	Success bool `json:"success"`
-}
-
 type relationshipItem struct {
 	ResourceID string `json:"resource_id,omitempty"`
 	Relation   string `json:"relation"`


### PR DESCRIPTION
NATS is the interface being used for relationship management now. relationshipCreate and relationshipDelete are redundant and also hard to make secure, since this part of the API is more of a management of the SpiceDB graph itself instead of management of resources that are on the SpiceDB graph. This commit removes both of them and their respective API routes.