### PR TITLE
update renovate to update all otel packages in a single pr

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,11 @@
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
+    },
+    {
+      "matchPackagePrefixes": ["go.opentelemetry.io"],
+      "groupName": "Update OTEL",
+      "groupSlug": "update-otel"
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
This ensures all otel packages are updates in the same pr which depend on each other.

Previously otel updates would frequently result in broken builds as many of the packages would get updated in separate renovate prs but depend on new updated packages. This should ensure they are all updated together.