### PR TITLE
use full consistent reads

### DIFF
--- a/cmd/createrole.go
+++ b/cmd/createrole.go
@@ -98,13 +98,12 @@ func createRole(ctx context.Context, cfg *config.AppConfig) {
 		logger.Fatalw("error creating subject resource", "error", err)
 	}
 
-	role, _, err := engine.CreateRole(ctx, resource, actions)
+	role, err := engine.CreateRole(ctx, resource, actions)
 	if err != nil {
 		logger.Fatalw("error creating role", "error", err)
 	}
 
-	_, err = engine.AssignSubjectRole(ctx, subjectResource, role)
-	if err != nil {
+	if err = engine.AssignSubjectRole(ctx, subjectResource, role); err != nil {
 		logger.Fatalw("error creating role", "error", err)
 	}
 

--- a/internal/api/assignments.go
+++ b/internal/api/assignments.go
@@ -50,7 +50,7 @@ func (r *Router) assignmentCreate(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "error getting resource").SetInternal(err)
 	}
 
-	resource, err := r.engine.GetRoleResource(ctx, roleResource, "")
+	resource, err := r.engine.GetRoleResource(ctx, roleResource)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error getting resource").SetInternal(err)
 	}
@@ -63,8 +63,7 @@ func (r *Router) assignmentCreate(c echo.Context) error {
 		ID: roleID,
 	}
 
-	_, err = r.engine.AssignSubjectRole(ctx, assigneeResource, role)
-	if err != nil {
+	if err = r.engine.AssignSubjectRole(ctx, assigneeResource, role); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error creating resource").SetInternal(err)
 	}
 
@@ -96,7 +95,7 @@ func (r *Router) assignmentsList(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "error getting resource").SetInternal(err)
 	}
 
-	resource, err := r.engine.GetRoleResource(ctx, roleResource, "")
+	resource, err := r.engine.GetRoleResource(ctx, roleResource)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error getting resource").SetInternal(err)
 	}
@@ -109,7 +108,7 @@ func (r *Router) assignmentsList(c echo.Context) error {
 		ID: roleID,
 	}
 
-	assignments, err := r.engine.ListAssignments(ctx, role, "")
+	assignments, err := r.engine.ListAssignments(ctx, role)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error listing assignments").SetInternal(err)
 	}
@@ -169,7 +168,7 @@ func (r *Router) assignmentDelete(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "error getting resource").SetInternal(err)
 	}
 
-	resource, err := r.engine.GetRoleResource(ctx, roleResource, "")
+	resource, err := r.engine.GetRoleResource(ctx, roleResource)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error getting resource").SetInternal(err)
 	}
@@ -182,8 +181,7 @@ func (r *Router) assignmentDelete(c echo.Context) error {
 		ID: roleID,
 	}
 
-	_, err = r.engine.UnassignSubjectRole(ctx, assigneeResource, role)
-	if err != nil {
+	if err = r.engine.UnassignSubjectRole(ctx, assigneeResource, role); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error deleting assignment").SetInternal(err)
 	}
 

--- a/internal/api/relationships.go
+++ b/internal/api/relationships.go
@@ -25,7 +25,7 @@ func (r *Router) relationshipListFrom(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "error listing relationships").SetInternal(err)
 	}
 
-	rels, err := r.engine.ListRelationshipsFrom(ctx, resource, "")
+	rels, err := r.engine.ListRelationshipsFrom(ctx, resource)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error listing relationships").SetInternal(err)
 	}
@@ -62,7 +62,7 @@ func (r *Router) relationshipListTo(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "error listing relationships").SetInternal(err)
 	}
 
-	rels, err := r.engine.ListRelationshipsTo(ctx, resource, "")
+	rels, err := r.engine.ListRelationshipsTo(ctx, resource)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error listing relationships").SetInternal(err)
 	}

--- a/internal/api/roles.go
+++ b/internal/api/roles.go
@@ -49,7 +49,7 @@ func (r *Router) roleCreate(c echo.Context) error {
 		return err
 	}
 
-	role, _, err := r.engine.CreateRole(ctx, resource, reqBody.Actions)
+	role, err := r.engine.CreateRole(ctx, resource, reqBody.Actions)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error creating resource").SetInternal(err)
 	}
@@ -85,7 +85,7 @@ func (r *Router) roleGet(c echo.Context) error {
 
 	// Roles belong to resources by way of the actions they can perform; do the permissions
 	// check on the role resource.
-	resource, err := r.engine.GetRoleResource(ctx, roleResource, "")
+	resource, err := r.engine.GetRoleResource(ctx, roleResource)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "error getting resource").SetInternal(err)
 	}
@@ -96,7 +96,7 @@ func (r *Router) roleGet(c echo.Context) error {
 		return err
 	}
 
-	role, err := r.engine.GetRole(ctx, roleResource, "")
+	role, err := r.engine.GetRole(ctx, roleResource)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error getting resource").SetInternal(err)
 	}
@@ -134,7 +134,7 @@ func (r *Router) rolesList(c echo.Context) error {
 		return err
 	}
 
-	roles, err := r.engine.ListRoles(ctx, resource, "")
+	roles, err := r.engine.ListRoles(ctx, resource)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error getting role").SetInternal(err)
 	}
@@ -178,7 +178,7 @@ func (r *Router) roleDelete(c echo.Context) error {
 
 	// Roles belong to resources by way of the actions they can perform; do the permissions
 	// check on the role resource.
-	resource, err := r.engine.GetRoleResource(ctx, roleResource, "")
+	resource, err := r.engine.GetRoleResource(ctx, roleResource)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "error getting resource").SetInternal(err)
 	}
@@ -187,8 +187,7 @@ func (r *Router) roleDelete(c echo.Context) error {
 		return err
 	}
 
-	_, err = r.engine.DeleteRole(ctx, roleResource, "")
-	if err != nil {
+	if err = r.engine.DeleteRole(ctx, roleResource); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error deleting resource").SetInternal(err)
 	}
 
@@ -222,7 +221,7 @@ func (r *Router) roleGetResource(c echo.Context) error {
 
 	// There's a little irony here in that getting a role's resource here is required to actually
 	// do the permissions check.
-	resource, err := r.engine.GetRoleResource(ctx, roleResource, "")
+	resource, err := r.engine.GetRoleResource(ctx, roleResource)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "error getting resource").SetInternal(err)
 	}

--- a/internal/pubsub/subscriber.go
+++ b/internal/pubsub/subscriber.go
@@ -160,8 +160,7 @@ func (s *Subscriber) processEvent(msg events.Request[events.AuthRelationshipRequ
 
 func (s *Subscriber) createRelationships(ctx context.Context, relationships []types.Relationship) error {
 	// Attempt to create the relationships in SpiceDB.
-	_, err := s.qe.CreateRelationships(ctx, relationships)
-	if err != nil {
+	if err := s.qe.CreateRelationships(ctx, relationships); err != nil {
 		return fmt.Errorf("%w: error creating relationships", err)
 	}
 
@@ -169,8 +168,7 @@ func (s *Subscriber) createRelationships(ctx context.Context, relationships []ty
 }
 
 func (s *Subscriber) deleteRelationships(ctx context.Context, relationships []types.Relationship) error {
-	_, err := s.qe.DeleteRelationships(ctx, relationships...)
-	if err != nil {
+	if err := s.qe.DeleteRelationships(ctx, relationships...); err != nil {
 		return err
 	}
 

--- a/internal/pubsub/subscriber_test.go
+++ b/internal/pubsub/subscriber_test.go
@@ -109,7 +109,7 @@ func TestNATS(t *testing.T) {
 			},
 			SetupFn: func(ctx context.Context, t *testing.T) context.Context {
 				var engine mock.Engine
-				engine.On("CreateRelationships").Return("", nil)
+				engine.On("CreateRelationships").Return(nil)
 
 				return context.WithValue(ctx, contextKeyEngine, &engine)
 			},
@@ -130,7 +130,7 @@ func TestNATS(t *testing.T) {
 			},
 			SetupFn: func(ctx context.Context, t *testing.T) context.Context {
 				var engine mock.Engine
-				engine.On("CreateRelationships").Return("", io.ErrUnexpectedEOF)
+				engine.On("CreateRelationships").Return(io.ErrUnexpectedEOF)
 
 				return context.WithValue(ctx, contextKeyEngine, &engine)
 			},
@@ -166,7 +166,7 @@ func TestNATS(t *testing.T) {
 			SetupFn: func(ctx context.Context, t *testing.T) context.Context {
 				var engine mock.Engine
 				engine.Namespace = "gooddelete"
-				engine.On("DeleteRelationships").Return("", nil)
+				engine.On("DeleteRelationships").Return(nil)
 
 				return context.WithValue(ctx, contextKeyEngine, &engine)
 			},

--- a/internal/query/mock/mock.go
+++ b/internal/query/mock/mock.go
@@ -26,24 +26,24 @@ type Engine struct {
 }
 
 // AssignSubjectRole does nothing but satisfies the Engine interface.
-func (e *Engine) AssignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) (string, error) {
-	return "", nil
+func (e *Engine) AssignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) error {
+	return nil
 }
 
 // UnassignSubjectRole does nothing but satisfies the Engine interface.
-func (e *Engine) UnassignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) (string, error) {
-	return "", nil
+func (e *Engine) UnassignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) error {
+	return nil
 }
 
 // CreateRelationships does nothing but satisfies the Engine interface.
-func (e *Engine) CreateRelationships(ctx context.Context, rels []types.Relationship) (string, error) {
+func (e *Engine) CreateRelationships(ctx context.Context, rels []types.Relationship) error {
 	args := e.Called()
 
-	return args.String(0), args.Error(1)
+	return args.Error(0)
 }
 
 // CreateRole creates a Role object and does not persist it anywhere.
-func (e *Engine) CreateRole(ctx context.Context, res types.Resource, actions []string) (types.Role, string, error) {
+func (e *Engine) CreateRole(ctx context.Context, res types.Resource, actions []string) (types.Role, error) {
 	// Copy actions instead of using the given slice
 	outActions := make([]string, len(actions))
 
@@ -54,58 +54,58 @@ func (e *Engine) CreateRole(ctx context.Context, res types.Resource, actions []s
 		Actions: outActions,
 	}
 
-	return role, "", nil
+	return role, nil
 }
 
 // GetRole returns nothing but satisfies the Engine interface.
-func (e *Engine) GetRole(ctx context.Context, roleResource types.Resource, queryToken string) (types.Role, error) {
+func (e *Engine) GetRole(ctx context.Context, roleResource types.Resource) (types.Role, error) {
 	return types.Role{}, nil
 }
 
 // GetRoleResource returns nothing but satisfies the Engine interface.
-func (e *Engine) GetRoleResource(ctx context.Context, roleResource types.Resource, queryToken string) (types.Resource, error) {
+func (e *Engine) GetRoleResource(ctx context.Context, roleResource types.Resource) (types.Resource, error) {
 	return types.Resource{}, nil
 }
 
 // ListAssignments returns nothing but satisfies the Engine interface.
-func (e *Engine) ListAssignments(ctx context.Context, role types.Role, queryToken string) ([]types.Resource, error) {
+func (e *Engine) ListAssignments(ctx context.Context, role types.Role) ([]types.Resource, error) {
 	return nil, nil
 }
 
 // ListRelationshipsFrom returns nothing but satisfies the Engine interface.
-func (e *Engine) ListRelationshipsFrom(ctx context.Context, resource types.Resource, queryToken string) ([]types.Relationship, error) {
+func (e *Engine) ListRelationshipsFrom(ctx context.Context, resource types.Resource) ([]types.Relationship, error) {
 	return nil, nil
 }
 
 // ListRelationshipsTo returns nothing but satisfies the Engine interface.
-func (e *Engine) ListRelationshipsTo(ctx context.Context, resource types.Resource, queryToken string) ([]types.Relationship, error) {
+func (e *Engine) ListRelationshipsTo(ctx context.Context, resource types.Resource) ([]types.Relationship, error) {
 	return nil, nil
 }
 
 // ListRoles returns nothing but satisfies the Engine interface.
-func (e *Engine) ListRoles(ctx context.Context, resource types.Resource, queryToken string) ([]types.Role, error) {
+func (e *Engine) ListRoles(ctx context.Context, resource types.Resource) ([]types.Role, error) {
 	return nil, nil
 }
 
 // DeleteRelationships does nothing but satisfies the Engine interface.
-func (e *Engine) DeleteRelationships(ctx context.Context, relationships ...types.Relationship) (string, error) {
+func (e *Engine) DeleteRelationships(ctx context.Context, relationships ...types.Relationship) error {
 	args := e.Called()
 
-	return args.String(0), args.Error(1)
+	return args.Error(0)
 }
 
 // DeleteRole does nothing but satisfies the Engine interface.
-func (e *Engine) DeleteRole(ctx context.Context, roleResource types.Resource, queryToken string) (string, error) {
+func (e *Engine) DeleteRole(ctx context.Context, roleResource types.Resource) error {
 	args := e.Called()
 
-	return args.String(0), args.Error(1)
+	return args.Error(0)
 }
 
 // DeleteResourceRelationships does nothing but satisfies the Engine interface.
-func (e *Engine) DeleteResourceRelationships(ctx context.Context, resource types.Resource) (string, error) {
+func (e *Engine) DeleteResourceRelationships(ctx context.Context, resource types.Resource) error {
 	args := e.Called()
 
-	return args.String(0), args.Error(1)
+	return args.Error(0)
 }
 
 // NewResourceFromID creates a new resource object based on the given ID.

--- a/internal/query/relations_test.go
+++ b/internal/query/relations_test.go
@@ -124,14 +124,14 @@ func TestCreateRoles(t *testing.T) {
 		tenRes, err := e.NewResourceFromID(tenID)
 		require.NoError(t, err)
 
-		_, queryToken, err := e.CreateRole(ctx, tenRes, actions)
+		_, err = e.CreateRole(ctx, tenRes, actions)
 		if err != nil {
 			return testingx.TestResult[[]types.Role]{
 				Err: err,
 			}
 		}
 
-		roles, err := e.ListRoles(ctx, tenRes, queryToken)
+		roles, err := e.ListRoles(ctx, tenRes)
 
 		return testingx.TestResult[[]types.Role]{
 			Success: roles,
@@ -151,7 +151,7 @@ func TestGetRoles(t *testing.T) {
 	tenRes, err := e.NewResourceFromID(tenID)
 	require.NoError(t, err)
 
-	role, queryToken, err := e.CreateRole(ctx, tenRes, []string{"loadbalancer_get"})
+	role, err := e.CreateRole(ctx, tenRes, []string{"loadbalancer_get"})
 	require.NoError(t, err)
 	roleRes, err := e.NewResourceFromID(role.ID)
 	require.NoError(t, err)
@@ -184,7 +184,7 @@ func TestGetRoles(t *testing.T) {
 	}
 
 	testFn := func(ctx context.Context, roleResource types.Resource) testingx.TestResult[types.Role] {
-		roles, err := e.GetRole(ctx, roleResource, queryToken)
+		roles, err := e.GetRole(ctx, roleResource)
 
 		return testingx.TestResult[types.Role]{
 			Success: roles,
@@ -205,9 +205,9 @@ func TestRoleDelete(t *testing.T) {
 	tenRes, err := e.NewResourceFromID(tenID)
 	require.NoError(t, err)
 
-	role, queryToken, err := e.CreateRole(ctx, tenRes, []string{"loadbalancer_get"})
+	role, err := e.CreateRole(ctx, tenRes, []string{"loadbalancer_get"})
 	require.NoError(t, err)
-	roles, err := e.ListRoles(ctx, tenRes, queryToken)
+	roles, err := e.ListRoles(ctx, tenRes)
 	require.NoError(t, err)
 	require.NotEmpty(t, roles)
 
@@ -237,14 +237,14 @@ func TestRoleDelete(t *testing.T) {
 			}
 		}
 
-		queryToken, err = e.DeleteRole(ctx, roleResource, queryToken)
+		err = e.DeleteRole(ctx, roleResource)
 		if err != nil {
 			return testingx.TestResult[[]types.Role]{
 				Err: err,
 			}
 		}
 
-		roles, err := e.ListRoles(ctx, tenRes, queryToken)
+		roles, err := e.ListRoles(ctx, tenRes)
 
 		return testingx.TestResult[[]types.Role]{
 			Success: roles,
@@ -268,7 +268,7 @@ func TestAssignments(t *testing.T) {
 	require.NoError(t, err)
 	subjRes, err := e.NewResourceFromID(subjID)
 	require.NoError(t, err)
-	role, _, err := e.CreateRole(
+	role, err := e.CreateRole(
 		ctx,
 		tenRes,
 		[]string{
@@ -293,14 +293,14 @@ func TestAssignments(t *testing.T) {
 	}
 
 	testFn := func(ctx context.Context, role types.Role) testingx.TestResult[[]types.Resource] {
-		queryToken, err := e.AssignSubjectRole(ctx, subjRes, role)
+		err := e.AssignSubjectRole(ctx, subjRes, role)
 		if err != nil {
 			return testingx.TestResult[[]types.Resource]{
 				Err: err,
 			}
 		}
 
-		resources, err := e.ListAssignments(ctx, role, queryToken)
+		resources, err := e.ListAssignments(ctx, role)
 
 		return testingx.TestResult[[]types.Resource]{
 			Success: resources,
@@ -324,7 +324,7 @@ func TestUnassignments(t *testing.T) {
 	require.NoError(t, err)
 	subjRes, err := e.NewResourceFromID(subjID)
 	require.NoError(t, err)
-	role, _, err := e.CreateRole(
+	role, err := e.CreateRole(
 		ctx,
 		tenRes,
 		[]string{
@@ -345,14 +345,14 @@ func TestUnassignments(t *testing.T) {
 	}
 
 	testFn := func(ctx context.Context, role types.Role) testingx.TestResult[[]types.Resource] {
-		queryToken, err := e.AssignSubjectRole(ctx, subjRes, role)
+		err := e.AssignSubjectRole(ctx, subjRes, role)
 		if err != nil {
 			return testingx.TestResult[[]types.Resource]{
 				Err: err,
 			}
 		}
 
-		resources, err := e.ListAssignments(ctx, role, queryToken)
+		resources, err := e.ListAssignments(ctx, role)
 		if err != nil {
 			return testingx.TestResult[[]types.Resource]{
 				Err: err,
@@ -371,14 +371,14 @@ func TestUnassignments(t *testing.T) {
 
 		require.True(t, found, "expected assignment to be found")
 
-		queryToken, err = e.UnassignSubjectRole(ctx, subjRes, role)
+		err = e.UnassignSubjectRole(ctx, subjRes, role)
 		if err != nil {
 			return testingx.TestResult[[]types.Resource]{
 				Err: err,
 			}
 		}
 
-		resources, err = e.ListAssignments(ctx, role, queryToken)
+		resources, err = e.ListAssignments(ctx, role)
 
 		return testingx.TestResult[[]types.Resource]{
 			Success: resources,
@@ -462,14 +462,14 @@ func TestRelationships(t *testing.T) {
 	}
 
 	testFn := func(ctx context.Context, input types.Relationship) testingx.TestResult[[]types.Relationship] {
-		queryToken, err := e.CreateRelationships(ctx, []types.Relationship{input})
+		err := e.CreateRelationships(ctx, []types.Relationship{input})
 		if err != nil {
 			return testingx.TestResult[[]types.Relationship]{
 				Err: err,
 			}
 		}
 
-		rels, err := e.ListRelationshipsFrom(ctx, input.Resource, queryToken)
+		rels, err := e.ListRelationshipsFrom(ctx, input.Resource)
 
 		return testingx.TestResult[[]types.Relationship]{
 			Success: rels,
@@ -500,10 +500,10 @@ func TestRelationshipDelete(t *testing.T) {
 		Subject:  parentRes,
 	}
 
-	queryToken, err := e.CreateRelationships(ctx, []types.Relationship{relReq})
+	err = e.CreateRelationships(ctx, []types.Relationship{relReq})
 	require.NoError(t, err)
 
-	createdResources, err := e.ListRelationshipsFrom(ctx, childRes, queryToken)
+	createdResources, err := e.ListRelationshipsFrom(ctx, childRes)
 	require.NoError(t, err)
 	require.NotEmpty(t, createdResources)
 
@@ -534,14 +534,14 @@ func TestRelationshipDelete(t *testing.T) {
 	}
 
 	testFn := func(ctx context.Context, input types.Relationship) testingx.TestResult[[]types.Relationship] {
-		queryToken, err := e.DeleteRelationships(ctx, input)
+		err := e.DeleteRelationships(ctx, input)
 		if err != nil {
 			return testingx.TestResult[[]types.Relationship]{
 				Err: err,
 			}
 		}
 
-		rels, err := e.ListRelationshipsFrom(ctx, input.Resource, queryToken)
+		rels, err := e.ListRelationshipsFrom(ctx, input.Resource)
 
 		return testingx.TestResult[[]types.Relationship]{
 			Success: rels,
@@ -569,7 +569,7 @@ func TestSubjectActions(t *testing.T) {
 	require.NoError(t, err)
 	subjRes, err := e.NewResourceFromID(subjID)
 	require.NoError(t, err)
-	role, _, err := e.CreateRole(
+	role, err := e.CreateRole(
 		ctx,
 		tenRes,
 		[]string{
@@ -577,7 +577,7 @@ func TestSubjectActions(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	_, err = e.AssignSubjectRole(ctx, subjRes, role)
+	err = e.AssignSubjectRole(ctx, subjRes, role)
 	assert.NoError(t, err)
 
 	type testInput struct {

--- a/internal/query/service.go
+++ b/internal/query/service.go
@@ -20,19 +20,19 @@ const (
 
 // Engine represents a client for making permissions queries.
 type Engine interface {
-	AssignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) (string, error)
-	UnassignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) (string, error)
-	CreateRelationships(ctx context.Context, rels []types.Relationship) (string, error)
-	CreateRole(ctx context.Context, res types.Resource, actions []string) (types.Role, string, error)
-	GetRole(ctx context.Context, roleResource types.Resource, queryToken string) (types.Role, error)
-	GetRoleResource(ctx context.Context, roleResource types.Resource, queryToken string) (types.Resource, error)
-	ListAssignments(ctx context.Context, role types.Role, queryToken string) ([]types.Resource, error)
-	ListRelationshipsFrom(ctx context.Context, resource types.Resource, queryToken string) ([]types.Relationship, error)
-	ListRelationshipsTo(ctx context.Context, resource types.Resource, queryToken string) ([]types.Relationship, error)
-	ListRoles(ctx context.Context, resource types.Resource, queryToken string) ([]types.Role, error)
-	DeleteRelationships(ctx context.Context, relationships ...types.Relationship) (string, error)
-	DeleteRole(ctx context.Context, roleResource types.Resource, queryToken string) (string, error)
-	DeleteResourceRelationships(ctx context.Context, resource types.Resource) (string, error)
+	AssignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) error
+	UnassignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) error
+	CreateRelationships(ctx context.Context, rels []types.Relationship) error
+	CreateRole(ctx context.Context, res types.Resource, actions []string) (types.Role, error)
+	GetRole(ctx context.Context, roleResource types.Resource) (types.Role, error)
+	GetRoleResource(ctx context.Context, roleResource types.Resource) (types.Resource, error)
+	ListAssignments(ctx context.Context, role types.Role) ([]types.Resource, error)
+	ListRelationshipsFrom(ctx context.Context, resource types.Resource) ([]types.Relationship, error)
+	ListRelationshipsTo(ctx context.Context, resource types.Resource) ([]types.Relationship, error)
+	ListRoles(ctx context.Context, resource types.Resource) ([]types.Role, error)
+	DeleteRelationships(ctx context.Context, relationships ...types.Relationship) error
+	DeleteRole(ctx context.Context, roleResource types.Resource) error
+	DeleteResourceRelationships(ctx context.Context, resource types.Resource) error
 	NewResourceFromID(id gidx.PrefixedID) (types.Resource, error)
 	GetResourceType(name string) *types.ResourceType
 	SubjectHasPermission(ctx context.Context, subject types.Resource, action string, resource types.Resource) error


### PR DESCRIPTION
This switches us to fully consistent reads of relationships which ensures after any action has been taken a subsequent read request will return the most up to date information.

This resolves an issue seen when directly after creating a role, a client may fail to assign a subject to the newly created role.