### PR TITLE
Cache ZedTokens for resources using NATS

### DIFF
--- a/chart/permissions-api/templates/_helpers.tpl
+++ b/chart/permissions-api/templates/_helpers.tpl
@@ -13,6 +13,11 @@
   secret:
     secretName: {{ . }}
 {{- end }}
+{{- with .Values.config.events.nats.credsSecretName }}
+- name: nats-creds
+  secret:
+    secretName: {{ . }}
+{{- end }}
 {{- with .Values.config.spicedb.policyConfigMapName }}
 - name: policy-file
   configMap:
@@ -26,6 +31,10 @@
 {{- if .Values.config.spicedb.caSecretName }}
 - name: spicedb-ca
   mountPath: /etc/ssl/spicedb/
+{{- end }}
+{{- if .Values.config.events.nats.credsSecretName }}
+- name: nats-creds
+  mountPath: /nats
 {{- end }}
 {{- if .Values.config.spicedb.policyConfigMapName }}
 - name: policy-file

--- a/chart/permissions-api/templates/config-server.yaml
+++ b/chart/permissions-api/templates/config-server.yaml
@@ -10,4 +10,4 @@ metadata:
     service: server
 data:
   config.yaml: |
-    {{- pick .Values.config "server" "oidc" "spicedb" "tracing" | toYaml | nindent 4 }}
+    {{- pick .Values.config "server" "oidc" "spicedb" "tracing" "events" | toYaml | nindent 4 }}

--- a/chart/permissions-api/values.yaml
+++ b/chart/permissions-api/values.yaml
@@ -47,6 +47,9 @@ config:
     policyConfigMapName: ""
 
   events:
+    # zedTokenBucket is the NATS bucket to use for caching ZedTokens
+    zedTokenBucket: ""
+
     # topics are the list of topics to subscribe to
     topics: []
 

--- a/cmd/kv.go
+++ b/cmd/kv.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"errors"
+
+	"github.com/nats-io/nats.go"
+	"go.infratographer.com/x/events"
+
+	"go.infratographer.com/permissions-api/internal/config"
+)
+
+var (
+	errInvalidSource = errors.New("events source must be a NATS connection")
+)
+
+func initializeKV(cfg config.EventsConfig, eventsConn events.Connection) (nats.KeyValue, error) {
+	// While in theory the events package supports any kind of broker, in practice we only
+	// support NATS.
+	natsConn, ok := eventsConn.Source().(*nats.Conn)
+	if !ok {
+		return nil, errInvalidSource
+	}
+
+	js, err := natsConn.JetStream()
+	if err != nil {
+		return nil, err
+	}
+
+	return js.KeyValue(cfg.ZedTokenBucket)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/authzed/authzed-go v0.10.1
 	github.com/authzed/grpcutil v0.0.0-20230908193239-4286bb1d6403
 	github.com/labstack/echo/v4 v4.11.3
+	github.com/nats-io/nats.go v1.31.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
@@ -58,7 +59,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nats-io/jwt/v2 v2.5.2 // indirect
 	github.com/nats-io/nats-server/v2 v2.10.4 // indirect
-	github.com/nats-io/nats.go v1.31.0 // indirect
 	github.com/nats-io/nkeys v0.4.6 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,8 +16,9 @@ import (
 
 // EventsConfig stores the configuration for a load-balancer-api events config
 type EventsConfig struct {
-	events.Config `mapstructure:",squash"`
-	Topics        []string
+	events.Config  `mapstructure:",squash"`
+	Topics         []string
+	ZedTokenBucket string
 }
 
 // AppConfig is the struct used for configuring the app
@@ -34,4 +35,7 @@ type AppConfig struct {
 func MustViperFlags(v *viper.Viper, flags *pflag.FlagSet) {
 	flags.StringSlice("events-topics", []string{}, "event topics to subscribe to")
 	viperx.MustBindFlag(v, "events.topics", flags.Lookup("events-topics"))
+
+	flags.String("events-zedtokenbucket", "", "NATS KV bucket to use for caching ZedTokens")
+	viperx.MustBindFlag(v, "events.zedtokenbucket", flags.Lookup("events-zedtokenbucket"))
 }

--- a/internal/query/relations_test.go
+++ b/internal/query/relations_test.go
@@ -19,7 +19,7 @@ import (
 	"go.infratographer.com/permissions-api/internal/types"
 )
 
-func testEngine(ctx context.Context, t *testing.T, namespace string) Engine {
+func testEngine(ctx context.Context, t *testing.T, namespace string) *engine {
 	config := spicedbx.Config{
 		Endpoint: "spicedb:50051",
 		Key:      "infradev",
@@ -52,10 +52,12 @@ func testEngine(ctx context.Context, t *testing.T, namespace string) Engine {
 		cleanDB(ctx, t, client, namespace)
 	})
 
+	// We call the constructor here to ensure the engine is created appropriately, but
+	// then return the underlying type so we can do testing with it.
 	out, err := NewEngine(namespace, client, kv, WithPolicy(policy))
 	require.NoError(t, err)
 
-	return out
+	return out.(*engine)
 }
 
 func testPolicy() iapl.Policy {

--- a/internal/query/zedtokens.go
+++ b/internal/query/zedtokens.go
@@ -1,0 +1,145 @@
+package query
+
+import (
+	"context"
+	"errors"
+
+	pb "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"go.infratographer.com/permissions-api/internal/types"
+)
+
+const (
+	consistencyMinimizeLatency = "minimize_latency"
+	consistencyAtLeastAsFresh  = "at_least_as_fresh"
+)
+
+// getLatestZedToken attempts to get the latest ZedToken for the given resource ID.
+func (e *engine) getLatestZedToken(ctx context.Context, resourceID string) (string, error) {
+	_, span := e.tracer.Start(
+		ctx,
+		"getLatestZedToken",
+		trace.WithAttributes(
+			attribute.String(
+				"permissions.resource",
+				resourceID,
+			),
+		),
+	)
+
+	defer span.End()
+
+	resp, err := e.kv.Get(resourceID)
+	if err != nil {
+		// Only record this as an error if it wasn't a not found error.
+		if !errors.Is(err, nats.ErrKeyNotFound) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+		}
+
+		return "", err
+	}
+
+	zedToken := string(resp.Value())
+
+	return zedToken, nil
+}
+
+// upsertZedToken updates the ZedToken at the given resource ID key with the provided ZedToken.
+func (e *engine) upsertZedToken(ctx context.Context, resourceID string, zedToken string) error {
+	_, span := e.tracer.Start(
+		ctx,
+		"upsertZedToken",
+		trace.WithAttributes(
+			attribute.String(
+				"permissions.resource",
+				resourceID,
+			),
+		),
+	)
+
+	defer span.End()
+
+	zedTokenBytes := []byte(zedToken)
+
+	// Attempt to get a ZedToken. If we found one, update it. If not, create it. If some other error
+	// happened, log that and return
+	resp, getErr := e.kv.Get(resourceID)
+
+	var err error
+
+	switch {
+	// If we found a token, update it. This may fail if another client updated it before we did
+	case getErr == nil:
+		_, err = e.kv.Update(resourceID, zedTokenBytes, resp.Revision())
+	// If we did not find a token, create it. This may fail if another client created an entry already
+	case errors.Is(getErr, nats.ErrKeyNotFound):
+		_, err = e.kv.Create(resourceID, zedTokenBytes)
+	// If something else happened, just keep moving
+	default:
+	}
+
+	// If an error happened when creating or updating the token, record it.
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+
+		return err
+	}
+
+	return nil
+}
+
+// updateRelationshipZedTokens updates the NATS KV bucket for ZedTokens, setting the given ZedToken
+// as the latest point in time snapshot for every resource in the given list of relationships.
+func (e *engine) updateRelationshipZedTokens(ctx context.Context, rels []types.Relationship, zedToken string) {
+	resourceIDMap := map[string]struct{}{}
+	for _, rel := range rels {
+		resourceIDMap[rel.Resource.ID.String()] = struct{}{}
+		resourceIDMap[rel.Subject.ID.String()] = struct{}{}
+	}
+
+	for resourceID := range resourceIDMap {
+		if err := e.upsertZedToken(ctx, resourceID, zedToken); err != nil {
+			e.logger.Warnw("error upserting ZedToken", "error", err.Error(), "resource_id", resourceID)
+		}
+	}
+}
+
+// determineConsistency produces a consistency strategy based on whether a ZedToken exists for a
+// given resource. If a ZedToken is available for the resource, at_least_as_fresh is used with the
+// retrieved ZedToken. If no such token is found, or if there is an error reaching NATS, minimize_latency
+// is used. This ensures that if NATS is not working or available for some reason, we can still make
+// permissions checks (albeit in a degraded state).
+func (e *engine) determineConsistency(ctx context.Context, resource types.Resource) (*pb.Consistency, string) {
+	resourceID := resource.ID.String()
+
+	zedToken, err := e.getLatestZedToken(ctx, resourceID)
+	if err != nil {
+		if !errors.Is(err, nats.ErrKeyNotFound) {
+			e.logger.Warnw("error getting latest ZedToken - falling back to minimize_latency", "error", err.Error(), "resource_id", resourceID)
+		}
+
+		consistency := &pb.Consistency{
+			Requirement: &pb.Consistency_MinimizeLatency{
+				MinimizeLatency: true,
+			},
+		}
+
+		return consistency, consistencyMinimizeLatency
+	}
+
+	consistency := &pb.Consistency{
+		Requirement: &pb.Consistency_AtLeastAsFresh{
+			AtLeastAsFresh: &pb.ZedToken{
+				Token: zedToken,
+			},
+		},
+	}
+
+	return consistency, consistencyAtLeastAsFresh
+}

--- a/internal/query/zedtokens_test.go
+++ b/internal/query/zedtokens_test.go
@@ -1,0 +1,80 @@
+package query
+
+import (
+	"context"
+	"testing"
+
+	"go.infratographer.com/permissions-api/internal/testingx"
+	"go.infratographer.com/permissions-api/internal/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.infratographer.com/x/gidx"
+)
+
+func TestConsistency(t *testing.T) {
+	namespace := "testconsistency"
+	ctx := context.Background()
+	e := testEngine(ctx, t, namespace)
+
+	tenantID, err := gidx.NewID("tnntten")
+	require.NoError(t, err)
+	tenantRes, err := e.NewResourceFromID(tenantID)
+	require.NoError(t, err)
+
+	parentID, err := gidx.NewID("tnntten")
+	require.NoError(t, err)
+	parentRes, err := e.NewResourceFromID(parentID)
+	require.NoError(t, err)
+
+	otherID, err := gidx.NewID("tnntten")
+	require.NoError(t, err)
+	otherRes, err := e.NewResourceFromID(otherID)
+	require.NoError(t, err)
+
+	testCases := []testingx.TestCase[types.Resource, string]{
+		{
+			Name:  "WithZedToken",
+			Input: tenantRes,
+			SetupFn: func(ctx context.Context, t *testing.T) context.Context {
+				rels := []types.Relationship{
+					{
+						Resource: tenantRes,
+						Relation: "parent",
+						Subject:  parentRes,
+					},
+				}
+
+				err := e.CreateRelationships(ctx, rels)
+
+				require.NoError(t, err)
+
+				return ctx
+			},
+			CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[string]) {
+				assert.NoError(t, res.Err)
+				assert.Equal(t, consistencyAtLeastAsFresh, res.Success)
+			},
+		},
+		{
+			Name:  "WithoutZedToken",
+			Input: otherRes,
+			CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[string]) {
+				assert.NoError(t, res.Err)
+				assert.Equal(t, consistencyMinimizeLatency, res.Success)
+			},
+		},
+	}
+
+	testFn := func(ctx context.Context, res types.Resource) testingx.TestResult[string] {
+		_, consistencyName := e.determineConsistency(ctx, res)
+
+		out := testingx.TestResult[string]{
+			Success: consistencyName,
+		}
+
+		return out
+	}
+
+	testingx.RunTests(ctx, t, testCases, testFn)
+}

--- a/permissions-api.example.yaml
+++ b/permissions-api.example.yaml
@@ -2,3 +2,7 @@ oidc:
   issuer: http://mock-oauth2-server:8081/default
 spicedb:
   policyFile: /workspace/policy.example.yaml
+events:
+  nats:
+    credsFile: /tmp/user.creds
+  zedTokenBucket: zedtokens


### PR DESCRIPTION
Using full consistency when doing permissions checks is slow. In general, this is addressed by using ZedTokens to indicate minimum bounds on freshness when looking up cached data. Something has to keep track of those tokens, either on the client side or server-side.

This PR introduces worker caching of ZedTokens for resources on updates to relationships and updates the query engine to use those tokens when performing permissions checks. When a worker updates a relationship, it persists the ZedToken for all resources directly affected by that update to a NATS KV bucket. NATS KV writes are immediately consistent, so the new ZedToken for that resource is available to all consumers, including permissions-api API frontends. When the query engine performs a permissions check, it checks to see if a ZedToken is available for the resource.

If a ZedToken was found, that ZedToken is used along with the `at_least_as_fresh` SpiceDB API consistency strategy. If not, or if there was an error accessing NATS, the query engine falls back to the `minimize_latency` API consistency strategy. If the NATS KV bucket is configured with a TTL at least as high as the quantization interval for SpiceDB, this ensures that by the time the ZedToken is evicted from the cache, all SpiceDB frontends will be updated with data at least as fresh as the last relationship update for a resource. Clients that wish to force an update for a resource (e.g., making role changes immediately available to tenant users) can thus issue a relationship update to permissions-api and get the latest data for that resource.

This PR assumes that the KV bucket used already exists; permissions-api will not attempt to create it. This is because the intention is that the KV bucket has a TTL set to something close to the SpiceDB quantization interval, which permissions-api is not necessarily aware of.