### PR TITLE
permit unconfigured permission checks

### DIFF
--- a/pkg/permissions/config.go
+++ b/pkg/permissions/config.go
@@ -8,11 +8,16 @@ import (
 
 // Config defines the permissions configuration structure
 type Config struct {
-	// URL is the URL checks should be executed against
+	// URL should point to a permissions-api authorization API route, such as https://example.com/api/v1/allow.
+	// If not set, all permissions checks will be denied by default. To override this behavior, set DefaultAllow
+	// to true.
 	URL string
 
 	// IgnoreNoResponders will ignore no responder errors when auth relationship requests are published.
 	IgnoreNoResponders bool
+
+	// DefaultAllow if set to true, will allow all permissions checks when URL is not set.
+	DefaultAllow bool
 }
 
 // MustViperFlags adds permissions config flags and viper bindings
@@ -22,4 +27,7 @@ func MustViperFlags(v *viper.Viper, flags *pflag.FlagSet) {
 
 	flags.Bool("permissions-ignore-no-responders", false, "ignores no responder errors when auth relationship requests are published")
 	viperx.MustBindFlag(v, "permissions.ignoreNoResponders", flags.Lookup("permissions-ignore-no-responders"))
+
+	flags.Bool("permissions-default-allow", false, "grant permission checks when url is not set")
+	viperx.MustBindFlag(v, "permissions.defaultAllow", flags.Lookup("permissions-default-allow"))
 }

--- a/pkg/permissions/permissions.go
+++ b/pkg/permissions/permissions.go
@@ -201,6 +201,10 @@ func New(config Config, options ...Option) (*Permissions, error) {
 		p.url = uri
 	}
 
+	if config.URL == "" && config.DefaultAllow {
+		p.defaultChecker = DefaultAllowChecker
+	}
+
 	for _, opt := range options {
 		if err := opt(p); err != nil {
 			return nil, err

--- a/pkg/permissions/permissions_test.go
+++ b/pkg/permissions/permissions_test.go
@@ -110,6 +110,18 @@ func TestPermissions(t *testing.T) {
 			nil,
 		},
 		{
+			"allow unconfigured checks",
+			permissions.Config{
+				DefaultAllow: true,
+			},
+			nil,
+			"",
+			"somersc-abc123",
+			"some-action",
+			nil,
+			nil,
+		},
+		{
 			"check allowed",
 			permissions.Config{
 				URL: srv.URL,


### PR DESCRIPTION
Easily permit permission checks when the permission library doesn't have a proper url configured.

This simplifies local development for service which implement permissions checks allowing them to skip calling out to a permissions service while developing locally by simply enabling `AllowUnconfiguredChecks`.