### PR TITLE
role-binding v2 schema and IAPL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,26 @@
 # Emacs stuff
 *~
 
+# vscode stuff
+.vscode/*
+.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
 # .tools dir
 .tools/
 
 # NATS dirs
 .devcontainer/nsc/
+resolver.conf
+
+# binary files
+permissions-api
+tmp

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -1,0 +1,415 @@
+# RBAC V2
+
+## Role-Bindings
+
+The following diagram describes the most basic role-binding relationships:
+
+```mermaid
+erDiagram
+  RoleBinding }o--|| Role : role
+  RoleBinding }o--o{ Subject : subject
+  Resource ||--o{ RoleBinding : grant
+
+  RoleBinding {
+    permission read_document
+    permission write_document
+    permission etc
+  }
+
+  Role {
+    relationship read_document_rel
+    relationship write_document_rel 
+    relationship etc
+  }
+
+  Resource {
+    permission read_document
+    permission write_document
+    permission etc
+  }
+```
+
+### RBAC IAPL
+
+In the IAPL, a new `rbac` directive is introduced to define the RBAC configurations.
+
+property | yaml | type | description
+-|-|-|-
+RoleResource |`rbac.roleresource`| string | name of the resource type that represents a role.
+RoleSubjectTypes |`rbac.rolesubjecttypes`| string | a list of subject types that the relationships in a role resource will contain.
+RoleOwners |`rbac.roleowners`| []string | the list of resource types that can own a role.  These resources should be (but not limited to) organizational resources like tenant, organization, project, group, etc When a role is owned by an entity, say a group, that means this role will be available to perform role-bindings for resources that are owned by this group and its subgroups.  The RoleOwners relationship is particularly useful to limit access to custom roles.
+RoleBindingResource |`rbac.rolebindingresource`| string | name of the resource type that represents a role binding.
+RoleBindingSubjects |`rbac.rolebindingsubjects`| []string | names of the resource types that can be subjects in a role binding.
+
+For example, consider the following spicedb schema:
+
+```zed
+
+ definition user {}
+ definition client {}
+
+ definition group {
+  relation member: user | client
+ }
+
+ definition organization {
+  relation parent: organization
+  relation member: user | client | organization#member
+  relation member_role: role | organization#member_role
+  relation grant: rolebinding
+
+  permissions rolebinding_list: grant->rolebinding_list
+  permissions rolebinding_create: grant->rolebinding_create
+  permissions rolebinding_delete: grant->rolebinding_delete
+ }
+
+ definition role {
+  relation owner: organization
+  relation view_organization: user:* | client:*
+  relation rolebinding_list_rel: user:* | client:*
+  relation rolebinding_create_rel: user:* | client:*
+  relation rolebinding_delete_rel: user:* | client:*
+ }
+
+ definition role_binding {
+  relation role: role
+  relation subject: user | group#member
+  permission view_organization = subject & role->view_organization
+  permissions rolebinding_list: subject & role->rolebinding_list
+  permissions rolebinding_create: subject & role->rolebinding_create
+  permissions rolebinding_delete: subject & role->rolebinding_delete
+ }
+
+```
+
+in IAPL policy terms:
+
+- the RoleResource would be "role"
+- the RoleBindingResource would be "role_binding",
+- the RoleRelationshipSubject would be `[user, client]`.
+- the RoleBindingSubjects would be `[{name: user}, {name: group, subjectrelation: member}]`.
+
+### Roles
+
+A `Role` is a spicedb entity that contains a set of permissions as relationships,
+in the form of:
+
+  ```zed
+  role:[role_id]#[permission_a]_rel@subject:*
+  role:[role_id]#[permission_b]_rel@subject:*
+  ```
+
+`subject:*` indicates any subjects [in possession](#bindings) of the role will be granted
+those permissions.
+
+### Bindings
+
+A `RoleBinding` establishes a three-way relationship between a role,
+a resource, and the subjects, in the form of:
+
+  ```zed
+  role_binding:[rb_id]#role@role:[role_id]
+  role_binding:[rb_id]#subject@subject:[subject_id]
+  resource:[res_id]#grant@role_binding:[rb_id]
+  ```
+
+### Permission Lookups
+
+Following is an example of looking up permission `read_doc` for subject `user_1`
+on a resource.
+
+Relationships:
+
+1. create role `doc_viewer`
+
+    ```zed
+    role:doc_viewer#read_doc_rel@subject:*
+    ```
+
+2. create role-binding
+
+    ```zed
+    role_binding:rb_1#role@role:doc_viwer
+    role_binding:rb_1#subject@subject:user_1
+    resource:res_1#grant@role_binding:rb_1
+    ```
+
+Lookup:
+
+```mermaid
+flowchart TD
+  res("`Resource:
+    permission: read_doc
+  `")
+
+  grant{Grant}
+  rb("`RoleBinding: rb_1`")
+
+  role_rel{Role}
+  role(doc_viwer)
+  perm>read_doc_rel]
+
+  subj_rel{Subj}
+  subj(user_1)
+
+  res-->grant
+  grant-->rb
+
+  rb-->role_rel
+  role_rel-->role
+  role-->perm
+  perm-->permok{{ok ✅}}
+
+  rb-->subj_rel
+  subj_rel-->subj
+  subj-->subjok{{ok ✅}}
+
+  permok-->ok{{ok ✅}}
+  subjok-->ok
+```
+
+## Hierarchical Grants
+
+In a lot of permissions scenarios, permission relationships are not as clean-cut
+as the example shown above. Most of the times, role-bindings involve binding a role to
+subjects on a higher level (e.g., projects, tenant, etc.,) and the users expect
+those permissions to be propagated all the resources that it owns. Moreover,
+there are cases where, instead of a single user or client being the role-binding
+subject, IAM users expect a role can be bind to a group of subjects. The IAPL
+is modified to generate a SpiceDB schema to accommodate these more complex
+use cases.
+
+### Ownerships
+
+To accommodate inheritance of the grant relationships,
+a new property `RoleBindingV2` is added to the resource type definitions
+and a new type of `Condition` is introduced to the IAPL:
+
+```diff
+  type ResourceType struct {
+    Name          string
+    IDPrefix      string
++   RoleBindingV2 *ResourceRoleBindingV2
+    Relationships []Relationship
+  }
+
+  type Condition struct {
+    RoleBinding        *ConditionRoleBinding
++   RoleBindingV2      *ConditionRoleBindingV2
+    RelationshipAction *ConditionRelationshipAction
+  }
+```
+
+A property of `InheritPermissionsFrom []string` is defined in `ResourceRoleBindingV2`
+that allows the IAPL to generate a permission line in the SpiceDB schema that
+allows grants and roles to be inherited from its owner or parent.
+
+When `RoleBindingV2` is defined in a given `Condition`, the IAPL will look for
+the `resourcetype.RoleBindingV2.InheritPermissionsFrom` property in the resource
+type that the condition's action belongs to.
+
+For example, consider the following `ActionBinding`:
+
+```yaml
+# ...
+
+resourcetypes:
+  - name: doc
+    idprefix: doc
+    rolebindingv2:
+      inheritpermissionsfrom:
+        - owner
+  - name: tenant
+    idprefix: tenant
+    rolebindingv2:
+      inheritpermissionsfrom:
+        - parent
+
+actionbindings:
+  - actionname: read_doc
+    typename: doc
+    conditions:
+      rolebindingv2: {}
+  - actionname: read_doc
+    typename: tenant
+    conditions:
+      rolebindingv2: {}
+
+# ...
+```
+
+The IAPL will generate the following SpiceDB schema:
+
+```zed
+definition doc {
+  relation owner: tenant
+  relation grant: role_binding
+  permissions read_doc: grant->read_doc + owner->read_doc
+}
+
+definition tenant {
+  relation parent: tenant
+  relation grant: role_binding
+  permissions read_doc: grant->read_doc + parent->read_doc
+}
+```
+
+#### Ownership Example
+
+Consider the following relationships, which is based on the one defined in
+[*permissions lookups*](#permission-lookups) section:
+
+```diff
+   # create role
+   role:doc_viewer#read_doc_rel@subject:*
+   
+   # grant role doc_viwer to user_1 on tenant parent
+   role_binding:rb_1#role@role:doc_viwer
+   role_binding:rb_1#subject@subject:user_1
+   tenant:parent#grant@role_binding:rb_1
+
++  # create child tenant
++  tenant:child#parent@tenant:parent
++  # create doc resource
++  doc:doc_1#owner@tenant:child
+```
+
+Lookup:
+
+```mermaid
+flowchart TD
+  doc("`Doc:
+    permission: read_doc
+  `")
+
+  tenant_child(Tenant: Child)
+  owner_rel{Owner}
+  tenant_parent(Tenant: Parent)
+  parent_rel{Parent}
+
+  grant{Grant}
+  rb("`RoleBinding: rb_1`")
+
+  role_rel{Role}
+  role(doc_viwer)
+  perm>read_doc_rel]
+
+  subj_rel{Subj}
+  subj(user_1)
+
+  doc-->owner_rel 
+  owner_rel-->tenant_child
+  tenant_child-->parent_rel
+  parent_rel-->tenant_parent
+
+  tenant_parent-->grant
+  grant-->rb
+
+  rb-->role_rel
+  role_rel-->role
+  role-->perm
+  perm-->permok{{ok ✅}}
+
+  rb-->subj_rel
+  subj_rel-->subj
+  subj-->subjok{{ok ✅}}
+
+  permok-->ok{{ok ✅}}
+  subjok-->ok
+```
+
+### Memberships
+
+To allowing groups, or any other type of resources with memberships to be the
+role-binding subject, all that is needed is to define the membership relationship
+in the `rbac.rolebindingsubjects` directive.
+
+For example, consider the following `rbac` directive:
+
+```yaml
+rbac:
+  rolebindingsubjects:
+    - name: user
+    - name: group
+      subjectrelation: member
+```
+
+this will generate the following SpiceDB schema:
+
+```zed
+definition role_binding {
+  relation role: role
+  relation subject: user | group#member
+  permission view_doc = subject & role->view_doc
+}
+```
+
+In this case, the `role_binding` entity can have a `subject` that is either a `user`
+or a member of the `group` entity.
+
+Consider the following relationships, which is based on the one defined in
+[*permissions lookups*](#permission-lookups) section:
+
+```diff
+   # create role
+   role:doc_viewer#read_doc_rel@subject:*
+
++  # create group_1
++  group:group_1#member@user:user_1
+   
++  # instead of binding to user_1, bind to group_1
+   role_binding:rb_1#role@role:doc_viwer
+-  role_binding:rb_1#subject@subject:user_1
++  role_binding:rb_2#subject@subject:group_1#member
+
+   tenant:parent#grant@role_binding:rb_1
+```
+
+Lookup:
+
+```mermaid
+flowchart TD
+  res("`Resource:
+    permission: read_doc
+  `")
+
+  grant{Grant}
+  rb("`RoleBinding: rb_1`")
+
+  role_rel{Role}
+  role(doc_viwer)
+  perm>read_doc_rel]
+
+  subj_rel{Subj}
+  subj(group_1)
+
+  member_rel{Member}
+  member(user_1)
+
+  res-->grant
+  grant-->rb
+
+  rb-->role_rel
+  role_rel-->role
+  role-->perm
+  perm-->permok{{ok ✅}}
+
+  rb-->subj_rel
+  subj_rel-->subj
+  subj-->member_rel
+  member_rel-->member
+  member-->memberok{{ok ✅}}
+
+  permok-->ok{{ok ✅}}
+  memberok-->ok
+```
+
+## Glossary
+
+- **Subject**: The entities that permissions can be granted to, such as users, clients, or group members
+- **Role**: An entity that contains a set of permissions
+- **RoleBinding**: An entity that creates a relationship between a role and some subjects,
+  meaning that these subjects are "in possession" of the permissions defined in the role
+- **Grant**: The relationship between a role-binding and a resource, effectively creating a
+  three way relationship between a role, a resource, and the subjects
+- **Inheritance**: The ability to propagate permissions and roles from a parent resource to its children

--- a/internal/iapl/default.go
+++ b/internal/iapl/default.go
@@ -1,5 +1,7 @@
 package iapl
 
+import "go.infratographer.com/permissions-api/internal/types"
+
 // DefaultPolicyDocument returns the default policy document for permissions-api.
 func DefaultPolicyDocument() PolicyDocument {
 	return PolicyDocument{
@@ -10,8 +12,8 @@ func DefaultPolicyDocument() PolicyDocument {
 				Relationships: []Relationship{
 					{
 						Relation: "subject",
-						TargetTypeNames: []string{
-							"subject",
+						TargetTypes: []types.TargetType{
+							{Name: "subject"},
 						},
 					},
 				},
@@ -30,8 +32,8 @@ func DefaultPolicyDocument() PolicyDocument {
 				Relationships: []Relationship{
 					{
 						Relation: "parent",
-						TargetTypeNames: []string{
-							"tenant",
+						TargetTypes: []types.TargetType{
+							{Name: "tenant"},
 						},
 					},
 				},
@@ -42,8 +44,8 @@ func DefaultPolicyDocument() PolicyDocument {
 				Relationships: []Relationship{
 					{
 						Relation: "owner",
-						TargetTypeNames: []string{
-							"resourceowner",
+						TargetTypes: []types.TargetType{
+							{Name: "resourceowner"},
 						},
 					},
 				},
@@ -52,15 +54,15 @@ func DefaultPolicyDocument() PolicyDocument {
 		Unions: []Union{
 			{
 				Name: "subject",
-				ResourceTypeNames: []string{
-					"user",
-					"client",
+				ResourceTypes: []types.TargetType{
+					{Name: "user"},
+					{Name: "client"},
 				},
 			},
 			{
 				Name: "resourceowner",
-				ResourceTypeNames: []string{
-					"tenant",
+				ResourceTypes: []types.TargetType{
+					{Name: "tenant"},
 				},
 			},
 		},

--- a/internal/iapl/errors.go
+++ b/internal/iapl/errors.go
@@ -15,4 +15,8 @@ var (
 	ErrorUnknownRelation = errors.New("unknown relation")
 	// ErrorUnknownAction represents an error where an action is not defined.
 	ErrorUnknownAction = errors.New("unknown action")
+	// ErrorMissingRelationship represents an error where a mandatory relationship is missing.
+	ErrorMissingRelationship = errors.New("missing relationship")
+	// ErrorDuplicateRBACDefinition represents an error where a duplicate RBAC definition was declared.
+	ErrorDuplicateRBACDefinition = errors.New("duplicated RBAC definition")
 )

--- a/internal/iapl/policy_test.go
+++ b/internal/iapl/policy_test.go
@@ -7,10 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.infratographer.com/permissions-api/internal/testingx"
+	"go.infratographer.com/permissions-api/internal/types"
 )
 
 func TestPolicy(t *testing.T) {
-	cases := []testingx.TestCase[PolicyDocument, struct{}]{
+	rbac := defaultRBAC()
+
+	cases := []testingx.TestCase[PolicyDocument, Policy]{
 		{
 			Name: "TypeExists",
 			Input: PolicyDocument{
@@ -22,13 +25,13 @@ func TestPolicy(t *testing.T) {
 				Unions: []Union{
 					{
 						Name: "foo",
-						ResourceTypeNames: []string{
-							"foo",
+						ResourceTypes: []types.TargetType{
+							{Name: "foo"},
 						},
 					},
 				},
 			},
-			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[struct{}]) {
+			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[Policy]) {
 				require.ErrorIs(t, res.Err, ErrorTypeExists)
 			},
 		},
@@ -43,13 +46,13 @@ func TestPolicy(t *testing.T) {
 				Unions: []Union{
 					{
 						Name: "bar",
-						ResourceTypeNames: []string{
-							"baz",
+						ResourceTypes: []types.TargetType{
+							{Name: "baz"},
 						},
 					},
 				},
 			},
-			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[struct{}]) {
+			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[Policy]) {
 				require.ErrorIs(t, res.Err, ErrorUnknownType)
 			},
 		},
@@ -64,13 +67,13 @@ func TestPolicy(t *testing.T) {
 				Unions: []Union{
 					{
 						Name: "bar",
-						ResourceTypeNames: []string{
-							"baz",
+						ResourceTypes: []types.TargetType{
+							{Name: "baz"},
 						},
 					},
 				},
 			},
-			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[struct{}]) {
+			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[Policy]) {
 				require.ErrorIs(t, res.Err, ErrorUnknownType)
 			},
 		},
@@ -83,15 +86,15 @@ func TestPolicy(t *testing.T) {
 						Relationships: []Relationship{
 							{
 								Relation: "bar",
-								TargetTypeNames: []string{
-									"baz",
+								TargetTypes: []types.TargetType{
+									{Name: "baz"},
 								},
 							},
 						},
 					},
 				},
 			},
-			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[struct{}]) {
+			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[Policy]) {
 				require.ErrorIs(t, res.Err, ErrorUnknownType)
 			},
 		},
@@ -104,8 +107,8 @@ func TestPolicy(t *testing.T) {
 						Relationships: []Relationship{
 							{
 								Relation: "bar",
-								TargetTypeNames: []string{
-									"foo",
+								TargetTypes: []types.TargetType{
+									{Name: "foo"},
 								},
 							},
 						},
@@ -123,7 +126,7 @@ func TestPolicy(t *testing.T) {
 					},
 				},
 			},
-			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[struct{}]) {
+			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[Policy]) {
 				require.ErrorIs(t, res.Err, ErrorUnknownAction)
 			},
 		},
@@ -136,8 +139,8 @@ func TestPolicy(t *testing.T) {
 						Relationships: []Relationship{
 							{
 								Relation: "bar",
-								TargetTypeNames: []string{
-									"foo",
+								TargetTypes: []types.TargetType{
+									{Name: "foo"},
 								},
 							},
 						},
@@ -163,7 +166,7 @@ func TestPolicy(t *testing.T) {
 					},
 				},
 			},
-			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[struct{}]) {
+			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[Policy]) {
 				require.ErrorIs(t, res.Err, ErrorUnknownAction)
 			},
 		},
@@ -195,7 +198,7 @@ func TestPolicy(t *testing.T) {
 					},
 				},
 			},
-			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[struct{}]) {
+			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[Policy]) {
 				require.ErrorIs(t, res.Err, ErrorUnknownRelation)
 			},
 		},
@@ -208,8 +211,8 @@ func TestPolicy(t *testing.T) {
 						Relationships: []Relationship{
 							{
 								Relation: "bar",
-								TargetTypeNames: []string{
-									"foo",
+								TargetTypes: []types.TargetType{
+									{Name: "foo"},
 								},
 							},
 						},
@@ -221,9 +224,9 @@ func TestPolicy(t *testing.T) {
 				Unions: []Union{
 					{
 						Name: "buzz",
-						ResourceTypeNames: []string{
-							"foo",
-							"baz",
+						ResourceTypes: []types.TargetType{
+							{Name: "foo"},
+							{Name: "baz"},
 						},
 					},
 				},
@@ -247,7 +250,7 @@ func TestPolicy(t *testing.T) {
 					},
 				},
 			},
-			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[struct{}]) {
+			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[Policy]) {
 				require.ErrorIs(t, res.Err, ErrorUnknownRelation)
 			},
 		},
@@ -260,8 +263,8 @@ func TestPolicy(t *testing.T) {
 						Relationships: []Relationship{
 							{
 								Relation: "bar",
-								TargetTypeNames: []string{
-									"foo",
+								TargetTypes: []types.TargetType{
+									{Name: "foo"},
 								},
 							},
 						},
@@ -271,8 +274,8 @@ func TestPolicy(t *testing.T) {
 						Relationships: []Relationship{
 							{
 								Relation: "bar",
-								TargetTypeNames: []string{
-									"foo",
+								TargetTypes: []types.TargetType{
+									{Name: "foo"},
 								},
 							},
 						},
@@ -281,9 +284,9 @@ func TestPolicy(t *testing.T) {
 				Unions: []Union{
 					{
 						Name: "buzz",
-						ResourceTypeNames: []string{
-							"foo",
-							"baz",
+						ResourceTypes: []types.TargetType{
+							{Name: "foo"},
+							{Name: "baz"},
 						},
 					},
 				},
@@ -307,7 +310,7 @@ func TestPolicy(t *testing.T) {
 					},
 				},
 			},
-			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[struct{}]) {
+			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[Policy]) {
 				require.ErrorIs(t, res.Err, ErrorUnknownAction)
 			},
 		},
@@ -320,8 +323,8 @@ func TestPolicy(t *testing.T) {
 						Relationships: []Relationship{
 							{
 								Relation: "bar",
-								TargetTypeNames: []string{
-									"foo",
+								TargetTypes: []types.TargetType{
+									{Name: "foo"},
 								},
 							},
 						},
@@ -331,8 +334,8 @@ func TestPolicy(t *testing.T) {
 						Relationships: []Relationship{
 							{
 								Relation: "bar",
-								TargetTypeNames: []string{
-									"foo",
+								TargetTypes: []types.TargetType{
+									{Name: "foo"},
 								},
 							},
 						},
@@ -341,9 +344,9 @@ func TestPolicy(t *testing.T) {
 				Unions: []Union{
 					{
 						Name: "buzz",
-						ResourceTypeNames: []string{
-							"foo",
-							"baz",
+						ResourceTypes: []types.TargetType{
+							{Name: "foo"},
+							{Name: "baz"},
 						},
 					},
 				},
@@ -367,21 +370,98 @@ func TestPolicy(t *testing.T) {
 					},
 				},
 			},
-			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[struct{}]) {
+			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[Policy]) {
 				require.NoError(t, res.Err)
+			},
+		},
+		{
+			Name: "NoRBACProvided",
+			Input: PolicyDocument{
+				ResourceTypes: []ResourceType{
+					{
+						Name: "foo",
+					},
+					{
+						Name:     "rolev2",
+						IDPrefix: "permrv2",
+					},
+					{
+						Name:     "role_binding",
+						IDPrefix: "permrbn",
+					},
+				},
+			},
+			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[Policy]) {
+				require.NoError(t, res.Err)
+				require.Nil(t, res.Success.RBAC())
+			},
+		},
+		{
+			Name: "RoleOwnerMissing",
+			Input: PolicyDocument{
+				RBAC: &rbac,
+				ResourceTypes: []ResourceType{
+					{
+						Name:     "rolev2",
+						IDPrefix: "permrv2",
+					},
+					{
+						Name:     "role_binding",
+						IDPrefix: "permrbn",
+					},
+				},
+			},
+			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[Policy]) {
+				// unknown resource type: role owner tenant does not exists
+				require.ErrorIs(t, res.Err, ErrorUnknownType)
+			},
+		},
+		{
+			Name: "RBAC_OK",
+			Input: PolicyDocument{
+				RBAC: &RBAC{
+					RoleResource:        RBACResourceDefinition{"rolev2", "permrv2"},
+					RoleBindingResource: RBACResourceDefinition{"role_binding", "permrbn"},
+					RoleSubjectTypes:    []string{"user"},
+					RoleOwners:          []string{"tenant"},
+					RoleBindingSubjects: []types.TargetType{{Name: "user"}},
+				},
+				ResourceTypes: []ResourceType{
+					{
+						Name: "tenant",
+					},
+					{
+						Name:     "user",
+						IDPrefix: "idntusr",
+					},
+				},
+			},
+			CheckFn: func(_ context.Context, t *testing.T, res testingx.TestResult[Policy]) {
+				require.NoError(t, res.Err)
+				require.NotNil(t, res.Success.RBAC())
 			},
 		},
 	}
 
-	testFn := func(_ context.Context, p PolicyDocument) testingx.TestResult[struct{}] {
-		policy := NewPolicy(p)
-		err := policy.Validate()
+	testFn := func(_ context.Context, doc PolicyDocument) testingx.TestResult[Policy] {
+		p := NewPolicy(doc)
+		err := p.Validate()
 
-		return testingx.TestResult[struct{}]{
-			Success: struct{}{},
+		return testingx.TestResult[Policy]{
+			Success: p,
 			Err:     err,
 		}
 	}
 
 	testingx.RunTests(context.Background(), t, cases, testFn)
+}
+
+func defaultRBAC() RBAC {
+	return RBAC{
+		RoleResource:        RBACResourceDefinition{"rolev2", "permrv2"},
+		RoleBindingResource: RBACResourceDefinition{"role_binding", "permrbn"},
+		RoleSubjectTypes:    []string{"user", "client"},
+		RoleOwners:          []string{"tenant"},
+		RoleBindingSubjects: []types.TargetType{{Name: "user"}, {Name: "client"}, {Name: "group", SubjectRelation: "member"}},
+	}
 }

--- a/internal/iapl/rbac.go
+++ b/internal/iapl/rbac.go
@@ -1,0 +1,222 @@
+package iapl
+
+import (
+	"go.infratographer.com/permissions-api/internal/types"
+)
+
+const (
+	// RoleOwnerRelation is the name of the relationship that connects a role to its owner.
+	RoleOwnerRelation = "owner"
+	// RoleOwnerMemberRoleRelation is the name of the relationship that connects a resource
+	// to a role that it owns
+	RoleOwnerMemberRoleRelation = "member_role"
+	// AvailableRolesList is the name of the action in a resource that returns a list
+	// of roles that are available for the resource
+	AvailableRolesList = "avail_role"
+	// RolebindingRoleRelation is the name of the relationship that connects a role binding to a role.
+	RolebindingRoleRelation = "role"
+	// RolebindingSubjectRelation is the name of the relationship that connects a role binding to a subject.
+	RolebindingSubjectRelation = "subject"
+	// RoleOwnerParentRelation is the name of the relationship that connects a role's owner to its parent.
+	RoleOwnerParentRelation = "parent"
+	// PermissionRelationSuffix is the suffix append to the name of the relationship
+	// representing a permission in a role
+	PermissionRelationSuffix = "_rel"
+	// GrantRelationship is the name of the relationship that connects a role binding to a resource.
+	GrantRelationship = "grant"
+)
+
+// RoleBindingAction is the list of actions that can be performed on a role-binding resource
+type RoleBindingAction string
+
+const (
+	// RoleBindingActionCreate is the action name to create a role binding
+	RoleBindingActionCreate RoleBindingAction = "rolebinding_create"
+	// RoleBindingActionUpdate is the action name to update a role binding
+	RoleBindingActionUpdate RoleBindingAction = "rolebinding_update"
+	// RoleBindingActionDelete is the action name to delete a role binding
+	RoleBindingActionDelete RoleBindingAction = "rolebinding_delete"
+	// RoleBindingActionGet is the action name to get a role binding
+	RoleBindingActionGet RoleBindingAction = "rolebinding_get"
+	// RoleBindingActionList is the action name to list role bindings
+	RoleBindingActionList RoleBindingAction = "rolebinding_list"
+)
+
+// ResourceRoleBindingV2 describes the relationships that will be created
+// for a resource to support role-binding V2
+type ResourceRoleBindingV2 struct {
+	// InheritPermissionsFrom is the list of resource types that can provide roles
+	// and grants to this resource
+	// Note that not all roles are available to all resources. This relationship is used to
+	// determine which roles are available to a resource.
+	// Before creating a role binding for a resource, one should check whether or
+	// not the role is available for the resource.
+	//
+	// Also see the RoleOwners field in the RBAC struct
+	InheritPermissionsFrom []string
+}
+
+/*
+RBAC represents a role-based access control policy.
+
+For example, consider the following spicedb schema:
+```zed
+
+	definition user {}
+	definition client {}
+
+	definition group {
+		relation member: user | client
+	}
+
+	definition organization {
+		relation parent: organization
+		relation member: user | client
+		relation member_role: role
+		relation grant: rolebinding
+
+		permissions rolebinding_list: grant->rolebinding_list
+		permissions rolebinding_create: grant->rolebinding_create
+		permissions rolebinding_delete: grant->rolebinding_delete
+	}
+
+	definition role {
+		relation owner: organization
+		relation view_organization: user:* | client:*
+		relation rolebinding_list_rel: user:* | client:*
+		relation rolebinding_create_rel: user:* | client:*
+		relation rolebinding_delete_rel: user:* | client:*
+	}
+
+	definition rolebinding {
+		relation role: role
+		relation subject: user | group#member
+		permission view_organization = subject & role->view_organization
+		permissions rolebinding_list: subject & role->rolebinding_list
+		permissions rolebinding_create: subject & role->rolebinding_create
+		permissions rolebinding_delete: subject & role->rolebinding_delete
+	}
+
+```
+in IAPL policy terms:
+- the RoleResource would be "{name: role, idprefix: someprefix}"
+- the RoleBindingResource would be "{name: rolebinding, idprefix: someprefix}",
+- the RoleRelationshipSubject would be `[user, client]`.
+- the RoleBindingSubjects would be `[{name: user}, {name: group, subjectrelation: member}]`.
+*/
+type RBAC struct {
+	// RoleResource is the name of the resource type that represents a role.
+	RoleResource RBACResourceDefinition
+	// RoleBindingResource is the name of the resource type that represents a role binding.
+	RoleBindingResource RBACResourceDefinition
+	// RoleSubjectTypes is a list of subject types that the relationships in a
+	// role resource will contain, see the example above.
+	RoleSubjectTypes []string
+	// RoleOwners is the list of resource types that can own a role.
+	// These resources should be (but not limited to) organizational resources
+	// like tenant, organization, project, group, etc
+	// When a role is owned by an entity, say a group, that means this role
+	// will be available to perform role-bindings for resources that are owned
+	// by this group and its subgroups.
+	// The RoleOwners relationship is particularly useful to limit access to
+	// custom roles.
+	RoleOwners []string
+	// RoleBindingSubjects is the names of the resource types that can be subjects in a role binding.
+	// e.g. rolebinding_create, rolebinding_list, rolebinding_delete
+	RoleBindingSubjects []types.TargetType
+
+	roleownersset map[string]struct{}
+}
+
+// RBACResourceDefinition is a struct to define a resource type for a role
+// and role-bindings
+type RBACResourceDefinition struct {
+	Name     string
+	IDPrefix string
+}
+
+// CreateRoleBindingConditionsForAction creates the conditions that is used for role binding v2,
+// for a given action name. e.g. for a doc_read action, it will create the following conditions:
+// doc_read = grant->doc_read + from[0]->doc_read + ... from[n]->doc_read
+func (r *RBAC) CreateRoleBindingConditionsForAction(actionName string, inheritFrom ...string) []types.Condition {
+	conds := make([]types.Condition, 0, len(inheritFrom)+1)
+
+	conds = append(conds, types.Condition{
+		RelationshipAction: &types.ConditionRelationshipAction{
+			Relation:   GrantRelationship,
+			ActionName: actionName,
+		},
+		RoleBindingV2: &types.ConditionRoleBindingV2{},
+	})
+
+	for _, from := range inheritFrom {
+		conds = append(conds, types.Condition{
+			RelationshipAction: &types.ConditionRelationshipAction{
+				Relation:   from,
+				ActionName: actionName,
+			},
+		})
+	}
+
+	return conds
+}
+
+// CreateRoleBindingActionsForResource should be used when an RBAC V2 condition
+// is created for an action, the resource that the action is belong to must
+// support role binding V2. This function creates the list of actions that can be performed
+// on a role binding resource.
+// e.g. If action `read_doc` is created with RBAC V2 condition, then the resource,
+// in this example `doc`, must also support actions like `rolebinding_create`.
+func (r *RBAC) CreateRoleBindingActionsForResource(inheritFrom ...string) []types.Action {
+	actionsStr := []RoleBindingAction{
+		RoleBindingActionCreate,
+		RoleBindingActionUpdate,
+		RoleBindingActionDelete,
+		RoleBindingActionGet,
+		RoleBindingActionList,
+	}
+
+	actions := make([]types.Action, 0, len(actionsStr))
+
+	for _, action := range actionsStr {
+		conditions := r.CreateRoleBindingConditionsForAction(string(action), inheritFrom...)
+		actions = append(actions, types.Action{Name: string(action), Conditions: conditions})
+	}
+
+	return actions
+}
+
+// RoleBindingActions returns the list of actions that can be performed on a role resource
+// plus the AvailableRoleRelation action that is used to decide whether or not
+// a role is available for a resource
+func (r *RBAC) RoleBindingActions() []Action {
+	actionsStr := []RoleBindingAction{
+		RoleBindingActionCreate,
+		RoleBindingActionUpdate,
+		RoleBindingActionDelete,
+		RoleBindingActionGet,
+		RoleBindingActionList,
+	}
+
+	actions := make([]Action, 0, len(actionsStr)+1)
+
+	for _, action := range actionsStr {
+		actions = append(actions, Action{Name: string(action)})
+	}
+
+	actions = append(actions, Action{Name: AvailableRolesList})
+
+	return actions
+}
+
+// RoleOwnersSet returns the set of role owners for easy role owner lookups
+func (r *RBAC) RoleOwnersSet() map[string]struct{} {
+	if r.roleownersset == nil {
+		r.roleownersset = make(map[string]struct{}, len(r.RoleOwners))
+		for _, owner := range r.RoleOwners {
+			r.roleownersset[owner] = struct{}{}
+		}
+	}
+
+	return r.roleownersset
+}

--- a/internal/query/relations_test.go
+++ b/internal/query/relations_test.go
@@ -75,8 +75,8 @@ func testPolicy() iapl.Policy {
 			Relationships: []iapl.Relationship{
 				{
 					Relation: "parent",
-					TargetTypeNames: []string{
-						"tenant",
+					TargetTypes: []types.TargetType{
+						{Name: "tenant"},
 					},
 				},
 			},

--- a/internal/spicedbx/schema_test.go
+++ b/internal/spicedbx/schema_test.go
@@ -39,9 +39,9 @@ func TestSchema(t *testing.T) {
 			Relationships: []types.ResourceTypeRelationship{
 				{
 					Relation: "subject",
-					Types: []string{
-						"user",
-						"client",
+					Types: []types.TargetType{
+						{Name: "user"},
+						{Name: "client"},
 					},
 				},
 			},
@@ -51,8 +51,32 @@ func TestSchema(t *testing.T) {
 			Relationships: []types.ResourceTypeRelationship{
 				{
 					Relation: "parent",
-					Types: []string{
-						"tenant",
+					Types: []types.TargetType{
+						{Name: "tenant"},
+					},
+				},
+				{
+					Relation: "loadbalancer_create_rel",
+					Types: []types.TargetType{
+						{Name: "role", SubjectRelation: "subject"},
+					},
+				},
+				{
+					Relation: "loadbalancer_get_rel",
+					Types: []types.TargetType{
+						{Name: "role", SubjectRelation: "subject"},
+					},
+				},
+				{
+					Relation: "port_create_rel",
+					Types: []types.TargetType{
+						{Name: "role", SubjectRelation: "subject"},
+					},
+				},
+				{
+					Relation: "port_get_rel",
+					Types: []types.TargetType{
+						{Name: "role", SubjectRelation: "subject"},
 					},
 				},
 			},
@@ -61,6 +85,9 @@ func TestSchema(t *testing.T) {
 					Name: "loadbalancer_create",
 					Conditions: []types.Condition{
 						{
+							RelationshipAction: &types.ConditionRelationshipAction{
+								Relation: "loadbalancer_create_rel",
+							},
 							RoleBinding: &types.ConditionRoleBinding{},
 						},
 						{
@@ -75,6 +102,9 @@ func TestSchema(t *testing.T) {
 					Name: "loadbalancer_get",
 					Conditions: []types.Condition{
 						{
+							RelationshipAction: &types.ConditionRelationshipAction{
+								Relation: "loadbalancer_get_rel",
+							},
 							RoleBinding: &types.ConditionRoleBinding{},
 						},
 						{
@@ -89,6 +119,9 @@ func TestSchema(t *testing.T) {
 					Name: "port_create",
 					Conditions: []types.Condition{
 						{
+							RelationshipAction: &types.ConditionRelationshipAction{
+								Relation: "port_create_rel",
+							},
 							RoleBinding: &types.ConditionRoleBinding{},
 						},
 						{
@@ -103,6 +136,9 @@ func TestSchema(t *testing.T) {
 					Name: "port_get",
 					Conditions: []types.Condition{
 						{
+							RelationshipAction: &types.ConditionRelationshipAction{
+								Relation: "port_get_rel",
+							},
 							RoleBinding: &types.ConditionRoleBinding{},
 						},
 						{
@@ -120,8 +156,14 @@ func TestSchema(t *testing.T) {
 			Relationships: []types.ResourceTypeRelationship{
 				{
 					Relation: "owner",
-					Types: []string{
-						"tenant",
+					Types: []types.TargetType{
+						{Name: "tenant"},
+					},
+				},
+				{
+					Relation: "loadbalancer_get_rel",
+					Types: []types.TargetType{
+						{Name: "role", SubjectRelation: "subject"},
 					},
 				},
 			},
@@ -130,6 +172,9 @@ func TestSchema(t *testing.T) {
 					Name: "loadbalancer_get",
 					Conditions: []types.Condition{
 						{
+							RelationshipAction: &types.ConditionRelationshipAction{
+								Relation: "loadbalancer_get_rel",
+							},
 							RoleBinding: &types.ConditionRoleBinding{},
 						},
 						{
@@ -147,8 +192,14 @@ func TestSchema(t *testing.T) {
 			Relationships: []types.ResourceTypeRelationship{
 				{
 					Relation: "owner",
-					Types: []string{
-						"tenant",
+					Types: []types.TargetType{
+						{Name: "tenant"},
+					},
+				},
+				{
+					Relation: "port_get_rel",
+					Types: []types.TargetType{
+						{Name: "role", SubjectRelation: "subject"},
 					},
 				},
 			},
@@ -157,6 +208,9 @@ func TestSchema(t *testing.T) {
 					Name: "port_get",
 					Conditions: []types.Condition{
 						{
+							RelationshipAction: &types.ConditionRelationshipAction{
+								Relation: "port_get_rel",
+							},
 							RoleBinding: &types.ConditionRoleBinding{},
 						},
 						{

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -20,14 +20,26 @@ type Role struct {
 	UpdatedAt  time.Time
 }
 
+// TargetType represents a relationship target, as defined in spiceDB's schema
+// reference: https://authzed.com/docs/reference/schema-lang#relations
+type TargetType struct {
+	Name              string
+	SubjectIdentifier string
+	SubjectRelation   string
+}
+
 // ResourceTypeRelationship is a relationship for a resource type.
 type ResourceTypeRelationship struct {
 	Relation string
-	Types    []string
+	Types    []TargetType
 }
 
 // ConditionRoleBinding represents a condition where a role binding is necessary to perform an action.
 type ConditionRoleBinding struct{}
+
+// ConditionRoleBindingV2 represents a condition where a role binding is necessary to perform an action.
+// This is the new version of the condition, and it is used to support the new role binding resource type.
+type ConditionRoleBindingV2 struct{}
 
 // ConditionRelationshipAction represents a condition where an action must be able to be performed
 // on another resource along a relation to perform an action.
@@ -39,13 +51,20 @@ type ConditionRelationshipAction struct {
 // Condition represents a required condition for performing an action.
 type Condition struct {
 	RoleBinding        *ConditionRoleBinding
+	RoleBindingV2      *ConditionRoleBindingV2
 	RelationshipAction *ConditionRelationshipAction
+}
+
+// ConditionSet is a set of conditions that must be met for the action to be performed.
+type ConditionSet struct {
+	Conditions []Condition
 }
 
 // Action represents a named thing a subject can do.
 type Action struct {
-	Name       string
-	Conditions []Condition
+	Name          string
+	Conditions    []Condition
+	ConditionSets []ConditionSet
 }
 
 // ResourceType defines a type of resource managed by the api
@@ -62,9 +81,26 @@ type Resource struct {
 	ID   gidx.PrefixedID
 }
 
+// RoleBindingSubjectCondition is the object that represents the condition of a
+// role binding subject.
+type RoleBindingSubjectCondition struct{}
+
+// RoleBindingSubject is the object that represents the subject of a role binding.
+type RoleBindingSubject struct {
+	SubjectResource Resource
+	Condition       *RoleBindingSubjectCondition
+}
+
 // Relationship represents a named association between a resource and a subject.
 type Relationship struct {
 	Resource Resource
 	Relation string
 	Subject  Resource
+}
+
+// RoleBinding represents a role binding between a role and a resource.
+type RoleBinding struct {
+	ID       gidx.PrefixedID
+	Role     Role
+	Subjects []RoleBindingSubject
 }

--- a/policies/policy.example.yaml
+++ b/policies/policy.example.yaml
@@ -1,34 +1,120 @@
+rbac:
+  roleresource:
+    name: rolev2
+    idprefix: permrv2
+  rolebindingresource: 
+    name: rolebinding
+    idprefix: permrbn
+  rolesubjecttypes:
+    - user
+    - client
+  roleowners:
+    - tenant
+  rolebindingsubjects:
+    - name: user
+    - name: client
+    - name: group
+      subjectrelation: member
+
+unions:
+  - name: group_member
+    resourcetypes:
+      - name: user
+      - name: client
+      - name: group
+        subjectrelation: member
+  - name: tenant_member
+    resourcetypes:
+      - name: user
+      - name: client
+      - name: group
+        subjectrelation: member
+      - name: tenant
+        subjectrelation: member
+  - name: resourceowner
+    resourcetypes:
+      - name: tenant
+  - name: resourceowner_relationship
+    resourcetypes:
+      - name: tenant
+      - name: tenant
+        subjectrelation: parent
+  - name: subject
+    resourcetypes:
+      - name: user
+      - name: client
+  - name: group_parent
+    resourcetypes:
+      - name: group
+      - name: group
+        subjectrelation: parent
+      - name: tenant
+      - name: tenant
+        subjectrelation: parent
+  - name: tenant_parent
+    resourcetypes:
+      - name: tenant
+      - name: tenant
+        subjectrelation: parent
+
 resourcetypes:
   - name: role
     idprefix: permrol
     relationships:
       - relation: subject
-        targettypenames:
-          - subject
+        targettypes:
+          - name: subject
+
   - name: user
     idprefix: idntusr
   - name: client
-    idprefix: idntcli
-  - name: tenant
-    idprefix: tnntten
+    idprefix: idntclt
+
+  - name: group
+    idprefix: idntgrp
+    rolebindingv2:
+      &rolesFromParent
+      inheritpermissionsfrom:
+        - parent
     relationships:
       - relation: parent
-        targettypenames:
-          - tenant
+        targettypes:
+          - name: group_parent
+      - relation: member
+        targettypes:
+          - name: group_member
+      - relation: grant
+        targettypes:
+          - name: rolebinding
+
+  - name: tenant
+    idprefix: tnntten
+    rolebindingv2:
+      *rolesFromParent
+    relationships:
+      - relation: parent
+        targettypes:
+          - name: tenant_parent
+      - relation: member
+        targettypes:
+          - name: tenant_member
+      - relation: grant
+        targettypes:
+          - name: rolebinding
+
   - name: loadbalancer
     idprefix: loadbal
+    rolebindingv2:
+      inheritpermissionsfrom:
+        - owner
     relationships:
       - relation: owner
-        targettypenames:
-          - resourceowner
-unions:
-  - name: subject
-    resourcetypenames:
-      - user
-      - client
-  - name: resourceowner
-    resourcetypenames:
-      - tenant
+        targettypes:
+          - name: resourceowner_relationship
+      - relation: grant
+        targettypes:
+          - name: rolebinding
+
 actions:
   - name: role_create
   - name: role_get
@@ -40,95 +126,142 @@ actions:
   - name: loadbalancer_list
   - name: loadbalancer_update
   - name: loadbalancer_delete
+
 actionbindings:
+  # role management - permissions on role
+  - actionname: role_get
+    typename: rolev2
+    conditions:
+      - relationshipaction:
+          relation: owner
+          actionname: role_get
+  - actionname: role_update
+    typename: rolev2
+    conditions:
+      - relationshipaction:
+          relation: owner
+          actionname: role_update
+  - actionname: role_delete
+    typename: rolev2
+    conditions:
+      - relationshipaction:
+          relation: owner
+          actionname: role_delete
+  # role management - permissions on owner
   - actionname: role_create
     typename: resourceowner
     conditions:
+      - rolebindingv2: {}
       - rolebinding: {}
-      - relationshipaction:
-          relation: parent
-          actionname: role_create
+  - actionname: role_create
+    typename: group
+    conditions:
+      - rolebindingv2: {}
+
   - actionname: role_get
     typename: resourceowner
     conditions:
+      - rolebindingv2: {}
       - rolebinding: {}
-      - relationshipaction:
-          relation: parent
-          actionname: role_get
+  - actionname: role_get
+    typename: group
+    conditions:
+      - rolebindingv2: {}
+
   - actionname: role_list
     typename: resourceowner
     conditions:
+      - rolebindingv2: {}
       - rolebinding: {}
-      - relationshipaction:
-          relation: parent
-          actionname: role_list
+  - actionname: role_list
+    typename: group
+    conditions:
+      - rolebindingv2: {}
+
   - actionname: role_update
     typename: resourceowner
     conditions:
+      - rolebindingv2: {}
       - rolebinding: {}
-      - relationshipaction:
-          relation: parent
-          actionname: role_update
+  - actionname: role_update
+    typename: group
+    conditions:
+      - rolebindingv2: {}
+
   - actionname: role_delete
     typename: resourceowner
     conditions:
+      - rolebindingv2: {}
       - rolebinding: {}
-      - relationshipaction:
-          relation: parent
-          actionname: role_delete
+  - actionname: role_delete
+    typename: group
+    conditions:
+      - rolebindingv2: {}
+
+  # loadbalancer management - permissions on loadbalancer
+  - actionname: loadbalancer_get
+    typename: loadbalancer
+    conditions:
+      - rolebinding: {}
+      - rolebindingv2: {}
+  - actionname: loadbalancer_update
+    typename: loadbalancer
+    conditions:
+      - rolebinding: {}
+      - rolebindingv2: {}
+  - actionname: loadbalancer_delete
+    typename: loadbalancer
+    conditions:
+      - rolebinding: {}
+      - rolebindingv2: {}
+
+  # loadbalancer management - permissions on owner
   - actionname: loadbalancer_create
     typename: resourceowner
     conditions:
+      - rolebindingv2: {}
       - rolebinding: {}
-      - relationshipaction:
-          relation: parent
-          actionname: loadbalancer_create
+  - actionname: loadbalancer_create
+    typename: group
+    conditions:
+      - rolebindingv2: {}
+  
   - actionname: loadbalancer_get
     typename: resourceowner
     conditions:
+      - rolebindingv2: {}
       - rolebinding: {}
-      - relationshipaction:
-          relation: parent
-          actionname: loadbalancer_get
-  - actionname: loadbalancer_update
-    typename: resourceowner
+  - actionname: loadbalancer_get
+    typename: group
     conditions:
-      - rolebinding: {}
-      - relationshipaction:
-          relation: parent
-          actionname: loadbalancer_update
+      - rolebindingv2: {}
+
   - actionname: loadbalancer_list
     typename: resourceowner
     conditions:
+      - rolebindingv2: {}
       - rolebinding: {}
-      - relationshipaction:
-          relation: parent
-          actionname: loadbalancer_list
+  - actionname: loadbalancer_list
+    typename: group
+    conditions:
+      - rolebindingv2: {}
+
+  - actionname: loadbalancer_update
+    typename: resourceowner
+    conditions:
+      - rolebindingv2: {}
+      - rolebinding: {}
+  - actionname: loadbalancer_update
+    typename: group
+    conditions:
+      - rolebindingv2: {}
+
   - actionname: loadbalancer_delete
     typename: resourceowner
     conditions:
+      - rolebindingv2: {}
       - rolebinding: {}
-      - relationshipaction:
-          relation: parent
-          actionname: loadbalancer_delete
-  - actionname: loadbalancer_get
-    typename: loadbalancer
-    conditions:
-      - rolebinding: {}
-      - relationshipaction:
-          relation: owner
-          actionname: loadbalancer_get
-  - actionname: loadbalancer_update
-    typename: loadbalancer
-    conditions:
-      - rolebinding: {}
-      - relationshipaction:
-          relation: owner
-          actionname: loadbalancer_update
   - actionname: loadbalancer_delete
-    typename: loadbalancer
+    typename: group
     conditions:
-      - rolebinding: {}
-      - relationshipaction:
-          relation: owner
-          actionname: loadbalancer_delete
+      - rolebindingv2: {}


### PR DESCRIPTION
In order to separate roles from bindings in permissions-api, we need to update the generated SpiceDB schema with a definition for bindings and permissions that check both direct assignment to roles and bindings (i.e., we don’t want to break existing assignments). The scope of this task is to update permissions-api to generate a SpiceDB schema with a binding definition that associates a subject (i.e., any principal) to a role.

see [this doc](https://github.com/infratographer/permissions-api/blob/41bcf2e66f9e8de28329580fd0c987cf1ae06cd6/docs/rbac.md) for more