### PR TITLE
correctly return message error if exists

### DIFF
--- a/pkg/permissions/relationships.go
+++ b/pkg/permissions/relationships.go
@@ -77,7 +77,7 @@ func (p *Permissions) submitAuthRelationshipRequest(ctx context.Context, topic s
 	}
 
 	if resp != nil {
-		if resp.Error() != nil {
+		if err := resp.Error(); err != nil {
 			errs = append(errs, err)
 		}
 


### PR DESCRIPTION
previously we were checking if the message had an error (which happens when the message fails to be decoded as json) and then we were promptly returning the nil error previously returned from the method request.

Now we capture the error returned by the `resp.Error()` method and return the error if one exists.