### PR TITLE
ensure validation errors include names for better context

### DIFF
--- a/internal/iapl/policy.go
+++ b/internal/iapl/policy.go
@@ -387,22 +387,22 @@ func (v *policy) validateActionBindings() error {
 		}
 
 		if _, ok := bindingMap[key]; ok {
-			return fmt.Errorf("%d: %w", i, ErrorActionBindingExists)
+			return fmt.Errorf("%d (%s:%s): %w", i, binding.TypeName, binding.ActionName, ErrorActionBindingExists)
 		}
 
 		bindingMap[key] = struct{}{}
 
 		if _, ok := v.ac[binding.ActionName]; !ok {
-			return fmt.Errorf("%d: %s: %w", i, binding.ActionName, ErrorUnknownAction)
+			return fmt.Errorf("%d (%s:%s): %s: %w", i, binding.TypeName, binding.ActionName, binding.ActionName, ErrorUnknownAction)
 		}
 
 		rt, ok := v.rt[binding.TypeName]
 		if !ok {
-			return fmt.Errorf("%d: %s: %w", i, binding.TypeName, ErrorUnknownType)
+			return fmt.Errorf("%d (%s:%s): %s: %w", i, binding.TypeName, binding.ActionName, binding.TypeName, ErrorUnknownType)
 		}
 
 		if err := v.validateConditions(rt, binding.Conditions); err != nil {
-			return fmt.Errorf("%d: conditions: %w", i, err)
+			return fmt.Errorf("%d (%s:%s): conditions: %w", i, binding.TypeName, binding.ActionName, err)
 		}
 	}
 


### PR DESCRIPTION
Errors previously only included their index to the particular portion which resulted in the error.

```
actionBindings: 92: conditions: 1: owner: unknown relation
```

This pr updates it to also include some details about the particular entry that resulted in the error to make it easier to locate the actual issue.

```
actionBindings: 318 (account:user): conditions: 1: owner: unknown relation
```