### PR TITLE
Watch for KV updates instead of reaching out for tokens

### DIFF
--- a/cmd/createrole.go
+++ b/cmd/createrole.go
@@ -114,6 +114,12 @@ func createRole(ctx context.Context, cfg *config.AppConfig) {
 		logger.Fatalw("error creating engine", "error", err)
 	}
 
+	defer func() {
+		if err := engine.Stop(); err != nil {
+			logger.Errorw("error stopping engine", "error", err)
+		}
+	}()
+
 	resource, err := engine.NewResourceFromID(resourceID)
 	if err != nil {
 		logger.Fatalw("error creating resource", "error", err)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -92,6 +92,12 @@ func serve(_ context.Context, cfg *config.AppConfig) {
 		logger.Fatalw("error creating engine", "error", err)
 	}
 
+	defer func() {
+		if err := engine.Stop(); err != nil {
+			logger.Errorw("error stopping engine", "error", err)
+		}
+	}()
+
 	srv, err := echox.NewServer(
 		logger.Desugar(),
 		echox.ConfigFromViper(viper.GetViper()),

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b
 	github.com/cockroachdb/cockroach-go/v2 v2.3.7
 	github.com/go-jose/go-jose/v4 v4.0.1
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/labstack/echo/v4 v4.11.4
 	github.com/nats-io/nats.go v1.34.1

--- a/go.sum
+++ b/go.sum
@@ -126,7 +126,6 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDa
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0QDGLKzqOmktBjT+Is=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/internal/query/mock/mock.go
+++ b/internal/query/mock/mock.go
@@ -23,6 +23,11 @@ type Engine struct {
 	schema    []types.ResourceType
 }
 
+// Stop does nothing but satisfies the Engine interface.
+func (e *Engine) Stop() error {
+	return nil
+}
+
 // AssignSubjectRole does nothing but satisfies the Engine interface.
 func (e *Engine) AssignSubjectRole(context.Context, types.Resource, types.Role) error {
 	args := e.Called()

--- a/internal/query/relations.go
+++ b/internal/query/relations.go
@@ -113,7 +113,7 @@ func (e *engine) SubjectHasPermission(ctx context.Context, subject types.Resourc
 
 	defer span.End()
 
-	consistency, consName := e.determineConsistency(ctx, resource)
+	consistency, consName := e.determineConsistency(resource)
 	span.SetAttributes(
 		attribute.String(
 			"permissions.consistency",

--- a/internal/query/relations_test.go
+++ b/internal/query/relations_test.go
@@ -60,6 +60,10 @@ func testEngine(ctx context.Context, t *testing.T, namespace string, policy iapl
 	out, err := NewEngine(namespace, client, kv, store, WithPolicy(policy))
 	require.NoError(t, err)
 
+	t.Cleanup(func() {
+		out.Stop() //nolint:errcheck
+	})
+
 	return out.(*engine)
 }
 

--- a/internal/query/zedtokens.go
+++ b/internal/query/zedtokens.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	pb "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -18,35 +19,64 @@ const (
 	consistencyAtLeastAsFresh  = "at_least_as_fresh"
 )
 
-// getLatestZedToken attempts to get the latest ZedToken for the given resource ID.
-func (e *engine) getLatestZedToken(ctx context.Context, resourceID string) (string, error) {
-	_, span := e.tracer.Start(
-		ctx,
-		"getLatestZedToken",
-		trace.WithAttributes(
-			attribute.String(
-				"permissions.resource",
-				resourceID,
-			),
-		),
-	)
-
-	defer span.End()
-
-	resp, err := e.kv.Get(resourceID)
+// initZedTokenCache creates a new LRU cache that watches KV for ZedToken updates.
+func (e *engine) initZedTokenCache() error {
+	status, err := e.kv.Status()
 	if err != nil {
-		// Only record this as an error if it wasn't a not found error.
-		if !errors.Is(err, nats.ErrKeyNotFound) {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-		}
-
-		return "", err
+		return err
 	}
 
-	zedToken := string(resp.Value())
+	ttl := status.TTL()
 
-	return zedToken, nil
+	keyWatcher, err := e.kv.WatchAll()
+	if err != nil {
+		return err
+	}
+
+	lru := expirable.NewLRU[string, string](0, nil, ttl)
+
+	e.keyWatcher = keyWatcher
+	e.zedTokenCache = lru
+
+	go func() {
+		for entry := range e.keyWatcher.Updates() {
+			if entry == nil {
+				continue
+			}
+
+			key := entry.Key()
+			value := string(entry.Value())
+
+			_, span := e.tracer.Start(
+				context.Background(),
+				"populateZedTokenCache",
+				trace.WithAttributes(
+					attribute.String(
+						"permissions.resource",
+						key,
+					),
+				),
+			)
+
+			e.zedTokenCache.Add(key, value)
+
+			span.End()
+		}
+	}()
+
+	return nil
+}
+
+// getLatestZedToken attempts to get the latest ZedToken for the given resource ID.
+func (e *engine) getLatestZedToken(resourceID string) (string, bool) {
+	resp, ok := e.zedTokenCache.Get(resourceID)
+	if !ok {
+		return "", false
+	}
+
+	zedToken := string(resp)
+
+	return zedToken, true
 }
 
 // upsertZedToken updates the ZedToken at the given resource ID key with the provided ZedToken.
@@ -112,18 +142,14 @@ func (e *engine) updateRelationshipZedTokens(ctx context.Context, rels []types.R
 
 // determineConsistency produces a consistency strategy based on whether a ZedToken exists for a
 // given resource. If a ZedToken is available for the resource, at_least_as_fresh is used with the
-// retrieved ZedToken. If no such token is found, or if there is an error reaching NATS, minimize_latency
-// is used. This ensures that if NATS is not working or available for some reason, we can still make
-// permissions checks (albeit in a degraded state).
-func (e *engine) determineConsistency(ctx context.Context, resource types.Resource) (*pb.Consistency, string) {
+// retrieved ZedToken. If no such token is found, minimize_latency is used. This ensures that if
+// NATS is not working or available for some reason, we can still make permissions checks (albeit
+// in a degraded state).
+func (e *engine) determineConsistency(resource types.Resource) (*pb.Consistency, string) {
 	resourceID := resource.ID.String()
 
-	zedToken, err := e.getLatestZedToken(ctx, resourceID)
-	if err != nil {
-		if !errors.Is(err, nats.ErrKeyNotFound) {
-			e.logger.Warnw("error getting latest ZedToken - falling back to minimize_latency", "error", err.Error(), "resource_id", resourceID)
-		}
-
+	zedToken, ok := e.getLatestZedToken(resourceID)
+	if !ok {
 		consistency := &pb.Consistency{
 			Requirement: &pb.Consistency_MinimizeLatency{
 				MinimizeLatency: true,


### PR DESCRIPTION
This PR updates the query engine to watch KV updates rather than reach out to the bucket for every permissions check. This is primarily done to improve performance at the expense of some consistency (i.e., the time it takes for a permissions-api server to receive an update).