### PR TITLE
Use HTTP 201 for role-binding creates

### DIFF
--- a/internal/api/rolebindings.go
+++ b/internal/api/rolebindings.go
@@ -79,7 +79,7 @@ func (r *Router) roleBindingCreate(c echo.Context) error {
 	}
 
 	return c.JSON(
-		http.StatusOK,
+		http.StatusCreated,
 		roleBindingResponse{
 			ID:         rb.ID,
 			ResourceID: rb.ResourceID,

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -843,7 +843,7 @@ paths:
                   subject_ids:
                     - idntgrp-my-subgroup
       responses:
-        "200":
+        "201":
           description: root-super-user / create-role-binding-group
           content:
             application/json:


### PR DESCRIPTION
When creating a rolebinding, the API should return `201` upon successful requests