### PR TITLE
update golangci-lint to v1.59.1

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,8 +1,6 @@
 run:
   build-tags:
     - testtools
-  skip-dirs:
-    - internal/models
 
 linters-settings:
   goimports:
@@ -23,15 +21,15 @@ linters:
 
     # additional linters
     - bodyclose
+    - err113
     - gocritic
     - gocyclo
-    - goerr113
     - gofmt
     # - gofumpt
     - goimports
-    - gomnd
     - govet
     - misspell
+    - mnd
     - noctx
     - revive
     - stylecheck
@@ -40,6 +38,8 @@ linters:
 
     # - bod
 issues:
+  exclude-dirs:
+    - internal/models
   exclude-rules:
     - path: (.+)_test.go
       linters:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ GCI_REPO = github.com/daixiang0/gci
 GCI_VERSION = v0.10.1
 
 GOLANGCI_LINT_REPO = github.com/golangci/golangci-lint
-GOLANGCI_LINT_VERSION = v1.57.2
+GOLANGCI_LINT_VERSION = v1.59.1
 
 NATS_CLI_REPO = github.com/nats-io/natscli
 NATS_CLI_VERSION = v0.0.35


### PR DESCRIPTION
Updates golangci-lint to v1.59.1 along with it's config file.