### PR TITLE
Use CRDB instead of SpiceDB for getting role resource

### DIFF
--- a/internal/query/relations.go
+++ b/internal/query/relations.go
@@ -1010,33 +1010,12 @@ func (e *engine) GetRole(ctx context.Context, roleResource types.Resource) (type
 
 // GetRoleResource gets the role's assigned resource.
 func (e *engine) GetRoleResource(ctx context.Context, roleResource types.Resource) (types.Resource, error) {
-	var (
-		resActions map[types.Resource][]string
-		err        error
-	)
-
-	for _, resType := range e.schemaRoleables {
-		resActions, err = e.listRoleResourceActions(ctx, roleResource, resType.Name)
-		if err != nil {
-			return types.Resource{}, err
-		}
-
-		// roles are only ever created for a single resource, so we can break after the first one is found.
-		if len(resActions) != 0 {
-			break
-		}
+	dbRole, err := e.store.GetRoleByID(ctx, roleResource.ID)
+	if err != nil {
+		return types.Resource{}, err
 	}
 
-	if len(resActions) > 1 {
-		return types.Resource{}, ErrRoleHasTooManyResources
-	}
-
-	// returns the first resources actions.
-	for resource := range resActions {
-		return resource, nil
-	}
-
-	return types.Resource{}, ErrRoleNotFound
+	return e.NewResourceFromID(dbRole.ResourceID)
 }
 
 // DeleteRole removes all role actions from the assigned resource.


### PR DESCRIPTION
Roles created with no actions are not able to be retrieved or deleted in permissions-api as a result of fetching the role's resource ID from SpiceDB rather than CRDB. This PR updates the storage engine to use CRDB instead.