### PR TITLE
Simplify role fetching logic in query engine

### DIFF
--- a/internal/query/relations.go
+++ b/internal/query/relations.go
@@ -913,12 +913,18 @@ func (e *engine) ListRoles(ctx context.Context, resource types.Resource) ([]type
 
 // listRoleResourceActions returns all resources and action relations for the provided resource type to the provided role.
 // Note: The actions returned by this function are the spicedb relationship action.
-func (e *engine) listRoleResourceActions(ctx context.Context, role types.Resource, resTypeName string) (map[types.Resource][]string, error) {
-	resType := e.namespace + "/" + resTypeName
+func (e *engine) listRoleResourceActions(ctx context.Context, role storage.Role) ([]string, error) {
+	roleOwnerResource, err := e.NewResourceFromID(role.ResourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	resType := e.namespace + "/" + roleOwnerResource.Type
 	roleType := e.namespace + "/role"
 
 	filter := &pb.RelationshipFilter{
-		ResourceType: resType,
+		ResourceType:       resType,
+		OptionalResourceId: roleOwnerResource.ID.String(),
 		OptionalSubjectFilter: &pb.SubjectFilter{
 			SubjectType:       roleType,
 			OptionalSubjectId: role.ID.String(),
@@ -933,84 +939,47 @@ func (e *engine) listRoleResourceActions(ctx context.Context, role types.Resourc
 		return nil, err
 	}
 
-	resourceIDActions := make(map[gidx.PrefixedID][]string)
+	out := make([]string, 0, len(relationships))
 
 	for _, rel := range relationships {
-		resourceID, err := gidx.Parse(rel.Resource.ObjectId)
-		if err != nil {
-			return nil, err
-		}
+		action := relationToAction(rel.Relation)
 
-		resourceIDActions[resourceID] = append(resourceIDActions[resourceID], rel.Relation)
+		out = append(out, action)
 	}
 
-	resourceActions := make(map[types.Resource][]string, len(resourceIDActions))
-
-	for resID, actions := range resourceIDActions {
-		res, err := e.NewResourceFromID(resID)
-		if err != nil {
-			return nil, err
-		}
-
-		resourceActions[res] = actions
-	}
-
-	return resourceActions, nil
+	return out, nil
 }
 
-// GetRole gets the role with it's actions.
+// GetRole gets the given role and its actions.
 func (e *engine) GetRole(ctx context.Context, roleResource types.Resource) (types.Role, error) {
-	var (
-		resActions map[types.Resource][]string
-		err        error
-	)
-
-	for _, resType := range e.schemaRoleables {
-		resActions, err = e.listRoleResourceActions(ctx, roleResource, resType.Name)
-		if err != nil {
-			return types.Role{}, err
-		}
-
-		// roles are only ever created for a single resource, so we can break after the first one is found.
-		if len(resActions) != 0 {
-			break
-		}
+	dbRole, err := e.getStorageRole(ctx, roleResource)
+	if err != nil {
+		return types.Role{}, err
 	}
 
-	if len(resActions) > 1 {
-		return types.Role{}, ErrRoleHasTooManyResources
+	actions, err := e.listRoleResourceActions(ctx, dbRole)
+	if err != nil {
+		return types.Role{}, err
 	}
 
-	// returns the first resources actions.
-	for _, actions := range resActions {
-		for i, action := range actions {
-			actions[i] = relationToAction(action)
-		}
+	out := types.Role{
+		ID:      roleResource.ID,
+		Name:    dbRole.Name,
+		Actions: actions,
 
-		dbRole, err := e.store.GetRoleByID(ctx, roleResource.ID)
-		if err != nil && !errors.Is(err, storage.ErrNoRoleFound) {
-			e.logger.Error("error while getting role", zap.Error(err))
-		}
-
-		return types.Role{
-			ID:      roleResource.ID,
-			Name:    dbRole.Name,
-			Actions: actions,
-
-			ResourceID: dbRole.ResourceID,
-			CreatedBy:  dbRole.CreatedBy,
-			UpdatedBy:  dbRole.UpdatedBy,
-			CreatedAt:  dbRole.CreatedAt,
-			UpdatedAt:  dbRole.UpdatedAt,
-		}, nil
+		ResourceID: dbRole.ResourceID,
+		CreatedBy:  dbRole.CreatedBy,
+		UpdatedBy:  dbRole.UpdatedBy,
+		CreatedAt:  dbRole.CreatedAt,
+		UpdatedAt:  dbRole.UpdatedAt,
 	}
 
-	return types.Role{}, ErrRoleNotFound
+	return out, nil
 }
 
 // GetRoleResource gets the role's assigned resource.
 func (e *engine) GetRoleResource(ctx context.Context, roleResource types.Resource) (types.Resource, error) {
-	dbRole, err := e.store.GetRoleByID(ctx, roleResource.ID)
+	dbRole, err := e.getStorageRole(ctx, roleResource)
 	if err != nil {
 		return types.Resource{}, err
 	}
@@ -1029,6 +998,16 @@ func (e *engine) DeleteRole(ctx context.Context, roleResource types.Resource) er
 		return err
 	}
 
+	dbRole, err := e.getStorageRole(ctx, roleResource)
+	if err != nil {
+		return err
+	}
+
+	roleOwnerResource, err := e.NewResourceFromID(dbRole.ResourceID)
+	if err != nil {
+		return err
+	}
+
 	err = e.store.LockRoleForUpdate(dbCtx, roleResource.ID)
 	if err != nil {
 		sErr := fmt.Errorf("failed to lock role: %s: %w", roleResource.ID, err)
@@ -1041,20 +1020,11 @@ func (e *engine) DeleteRole(ctx context.Context, roleResource types.Resource) er
 		return err
 	}
 
-	var resActions map[types.Resource][]string
+	actions, err := e.listRoleResourceActions(ctx, dbRole)
+	if err != nil {
+		logRollbackErr(e.logger, e.store.RollbackContext(dbCtx))
 
-	for _, resType := range e.schemaRoleables {
-		resActions, err = e.listRoleResourceActions(ctx, roleResource, resType.Name)
-		if err != nil {
-			logRollbackErr(e.logger, e.store.RollbackContext(dbCtx))
-
-			return err
-		}
-
-		// roles are only ever created for a single resource, so we can break after the first one is found.
-		if len(resActions) != 0 {
-			break
-		}
+		return err
 	}
 
 	roleType := e.namespace + "/role"
@@ -1069,15 +1039,16 @@ func (e *engine) DeleteRole(ctx context.Context, roleResource types.Resource) er
 		},
 	}
 
-	for resource, relActions := range resActions {
-		for _, relAction := range relActions {
-			filters = append(filters, &pb.RelationshipFilter{
-				ResourceType:          e.namespace + "/" + resource.Type,
-				OptionalResourceId:    resource.ID.String(),
-				OptionalRelation:      relAction,
-				OptionalSubjectFilter: roleSubjectFilter,
-			})
-		}
+	ownerType := e.namespace + "/" + roleOwnerResource.Type
+	ownerIDStr := roleOwnerResource.ID.String()
+
+	for _, relAction := range actions {
+		filters = append(filters, &pb.RelationshipFilter{
+			ResourceType:          ownerType,
+			OptionalResourceId:    ownerIDStr,
+			OptionalRelation:      relAction,
+			OptionalSubjectFilter: roleSubjectFilter,
+		})
 	}
 
 	_, err = e.store.DeleteRole(dbCtx, roleResource.ID)
@@ -1228,4 +1199,17 @@ func (e *engine) applyUpdates(ctx context.Context, updates []*pb.RelationshipUpd
 	}
 
 	return nil
+}
+
+func (e *engine) getStorageRole(ctx context.Context, roleResource types.Resource) (storage.Role, error) {
+	dbRole, err := e.store.GetRoleByID(ctx, roleResource.ID)
+
+	switch {
+	case err == nil:
+		return dbRole, nil
+	case errors.Is(err, storage.ErrNoRoleFound):
+		return storage.Role{}, ErrRoleNotFound
+	default:
+		return storage.Role{}, err
+	}
 }

--- a/internal/query/relations_test.go
+++ b/internal/query/relations_test.go
@@ -13,7 +13,6 @@ import (
 
 	"go.infratographer.com/permissions-api/internal/iapl"
 	"go.infratographer.com/permissions-api/internal/spicedbx"
-	"go.infratographer.com/permissions-api/internal/storage"
 	"go.infratographer.com/permissions-api/internal/storage/teststore"
 	"go.infratographer.com/permissions-api/internal/testingx"
 	"go.infratographer.com/permissions-api/internal/types"
@@ -246,7 +245,7 @@ func TestRoleUpdate(t *testing.T) {
 			Input: gidx.MustNewID(RolePrefix),
 			CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[types.Role]) {
 				require.Error(t, res.Err)
-				assert.ErrorIs(t, res.Err, storage.ErrNoRoleFound)
+				assert.ErrorIs(t, res.Err, ErrRoleNotFound)
 			},
 		},
 		{

--- a/internal/query/roles_v2.go
+++ b/internal/query/roles_v2.go
@@ -202,7 +202,7 @@ func (e *engine) GetRoleV2(ctx context.Context, role types.Resource) (types.Role
 	}
 
 	// 2. Get role info (name, created_by, etc.) from permissions API DB
-	dbrole, err := e.store.GetRoleByID(ctx, role.ID)
+	dbrole, err := e.getStorageRole(ctx, role)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -399,7 +399,7 @@ func (e *engine) DeleteRoleV2(ctx context.Context, roleResource types.Resource) 
 		return err
 	}
 
-	dbRole, err := e.store.GetRoleByID(dbCtx, roleResource.ID)
+	dbRole, err := e.getStorageRole(dbCtx, roleResource)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())

--- a/internal/query/roles_v2.go
+++ b/internal/query/roles_v2.go
@@ -234,7 +234,7 @@ func (e *engine) UpdateRoleV2(ctx context.Context, actor, roleResource types.Res
 		return types.Role{}, err
 	}
 
-	err = e.store.LockRoleForUpdate(dbCtx, roleResource.ID)
+	err = e.lockRoleForUpdate(dbCtx, roleResource)
 	if err != nil {
 		sErr := fmt.Errorf("failed to lock role: %s: %w", roleResource.ID, err)
 
@@ -360,7 +360,7 @@ func (e *engine) DeleteRoleV2(ctx context.Context, roleResource types.Resource) 
 		return err
 	}
 
-	err = e.store.LockRoleForUpdate(dbCtx, roleResource.ID)
+	err = e.lockRoleForUpdate(dbCtx, roleResource)
 	if err != nil {
 		sErr := fmt.Errorf("failed to lock role: %s: %w", roleResource.ID, err)
 

--- a/internal/query/roles_v2_test.go
+++ b/internal/query/roles_v2_test.go
@@ -11,7 +11,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"go.infratographer.com/permissions-api/internal/iapl"
-	"go.infratographer.com/permissions-api/internal/storage"
 	"go.infratographer.com/permissions-api/internal/testingx"
 	"go.infratographer.com/permissions-api/internal/types"
 )
@@ -176,7 +175,7 @@ func TestGetRoleV2(t *testing.T) {
 			Name:  "GetRoleNotFound",
 			Input: missingRes,
 			CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[types.Role]) {
-				assert.ErrorIs(t, res.Err, storage.ErrNoRoleFound)
+				assert.ErrorIs(t, res.Err, ErrRoleNotFound)
 			},
 		},
 		{
@@ -324,7 +323,7 @@ func TestUpdateRolesV2(t *testing.T) {
 				role:    notfoundRes,
 			},
 			CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[types.Role]) {
-				assert.ErrorIs(t, res.Err, storage.ErrNoRoleFound)
+				assert.ErrorIs(t, res.Err, ErrRoleNotFound)
 			},
 			Sync: true,
 		},
@@ -460,7 +459,7 @@ func TestDeleteRolesV2(t *testing.T) {
 			Name:  "DeleteRoleNotFound",
 			Input: notfoundRes,
 			CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[types.Role]) {
-				assert.ErrorIs(t, res.Err, storage.ErrNoRoleFound)
+				assert.ErrorIs(t, res.Err, ErrRoleNotFound)
 			},
 			Sync: true,
 		},
@@ -510,7 +509,7 @@ func TestDeleteRolesV2(t *testing.T) {
 				assert.NoError(t, res.Err)
 
 				_, err := e.GetRoleV2(ctx, roleRes)
-				assert.ErrorIs(t, err, storage.ErrNoRoleFound)
+				assert.ErrorIs(t, err, ErrRoleNotFound)
 			},
 			Sync: true,
 		},

--- a/internal/storage/errors.go
+++ b/internal/storage/errors.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	// ErrNoRoleFound is returned when no role is found when retrieving or deleting a role.
-	ErrNoRoleFound = errors.New("role not found")
+	ErrNoRoleFound = errors.New("role not found in database")
 
 	// ErrRoleAlreadyExists is returned when creating a role which already has an existing record.
 	ErrRoleAlreadyExists = errors.New("role already exists")


### PR DESCRIPTION
Prior implementations of the query engine fetched role information such as the owning resource ID directly from SpiceDB, as it was the only data store available. With the introduction of CRDB, that is no longer the case and the CRDB SQL table should be considered the authoritative source of most role data. This PR updates the query engine to fetch role resource owner ID and other data from the SQL DB whenever possible, getting rid of some obscure failure modes that occur when a role has no associated actions.