### PR TITLE
Don't defaulty inherit all actions for role binding v2

### DIFF
--- a/internal/iapl/policy.go
+++ b/internal/iapl/policy.go
@@ -799,7 +799,11 @@ func (v *policy) Schema() []types.ResourceType {
 
 				typeMap[b.TypeName].Relationships = append(typeMap[b.TypeName].Relationships, actionRel)
 			case c.RoleBindingV2 != nil && res.RoleBindingV2 != nil:
-				conditions = v.RBAC().CreateRoleBindingConditionsForAction(actionName, res.RoleBindingV2.InheritPermissionsFrom...)
+				if res.RoleBindingV2.InheritAllActions {
+					conditions = v.RBAC().CreateRoleBindingConditionsForAction(actionName, res.RoleBindingV2.InheritPermissionsFrom...)
+				} else {
+					conditions = v.RBAC().CreateRoleBindingConditionsForAction(actionName)
+				}
 
 				// add role-binding v2 conditions to the resource, if not exists
 				if _, ok := rbv2Actions[b.TypeName]; !ok {

--- a/internal/iapl/rbac.go
+++ b/internal/iapl/rbac.go
@@ -70,6 +70,9 @@ type ResourceRoleBindingV2 struct {
 	//
 	// Also see the RoleOwners field in the RBAC struct
 	InheritPermissionsFrom []string
+
+	// InheritAllActions adds relationship action lookups for all actions, not just role binding actions.
+	InheritAllActions bool
 }
 
 /*

--- a/internal/query/default_test.go
+++ b/internal/query/default_test.go
@@ -96,6 +96,7 @@ func DefaultPolicyDocumentV2() iapl.PolicyDocument {
 				IDPrefix: "idntgrp",
 				RoleBindingV2: &iapl.ResourceRoleBindingV2{
 					InheritPermissionsFrom: []string{"parent"},
+					InheritAllActions:      true,
 				},
 				Relationships: []iapl.Relationship{
 					{Relation: "parent", TargetTypes: []types.TargetType{{Name: "group_parent"}}},
@@ -108,6 +109,7 @@ func DefaultPolicyDocumentV2() iapl.PolicyDocument {
 				IDPrefix: "tnntten",
 				RoleBindingV2: &iapl.ResourceRoleBindingV2{
 					InheritPermissionsFrom: []string{"parent"},
+					InheritAllActions:      true,
 				},
 				Relationships: []iapl.Relationship{
 					{Relation: "parent", TargetTypes: []types.TargetType{{Name: "tenant_parent"}}},
@@ -120,6 +122,7 @@ func DefaultPolicyDocumentV2() iapl.PolicyDocument {
 				IDPrefix: "loadbal",
 				RoleBindingV2: &iapl.ResourceRoleBindingV2{
 					InheritPermissionsFrom: []string{"owner"},
+					InheritAllActions:      true,
 				},
 				Relationships: []iapl.Relationship{
 					{Relation: "owner", TargetTypes: []types.TargetType{{Name: "resourceowner_relationship"}}},

--- a/policies/policy.example.yaml
+++ b/policies/policy.example.yaml
@@ -44,10 +44,10 @@ resourcetypes:
 
   - name: tenant
     idprefix: tnntten
-    rolebindingv2:
-      &permsFromParent
+    rolebindingv2: &permsFromParent
       inheritpermissionsfrom:
         - parent
+      inheritallactions: true
     relationships:
       - relation: parent
         targettypes:
@@ -80,6 +80,7 @@ resourcetypes:
     rolebindingv2:
       inheritpermissionsfrom:
         - owner
+      inheritallactions: true
     relationships:
       - relation: owner
         targettypes:


### PR DESCRIPTION
By default when specifying `InheritPermissionsFrom` on resource type's RoleBindingV2 all actions were being inherited rather than only inheriting RBAC v2 actions.

This change reduces the default inheritance to only the RBAC v2 actions but setting `InheritAllActions` to `true` will automatically include inheritance for all configured actions on that resource type.