### PR TITLE
add manager field to simplify multi service management

### DIFF
--- a/cmd/createrole.go
+++ b/cmd/createrole.go
@@ -113,7 +113,7 @@ func createRole(ctx context.Context, cfg *config.AppConfig) {
 		logger.Fatalw("error creating subject resource", "error", err)
 	}
 
-	role, err := engine.CreateRoleV2(ctx, subjectResource, resource, name, actions)
+	role, err := engine.CreateRoleV2(ctx, subjectResource, resource, "", name, actions)
 	if err != nil {
 		logger.Fatalw("error creating role", "error", err)
 	}
@@ -125,7 +125,7 @@ func createRole(ctx context.Context, cfg *config.AppConfig) {
 		logger.Fatalw("error creating role resource", "error", err)
 	}
 
-	rb, err := engine.CreateRoleBinding(ctx, subjectResource, resource, roleres, rbsubj)
+	rb, err := engine.CreateRoleBinding(ctx, subjectResource, resource, roleres, "", rbsubj)
 	if err != nil {
 		logger.Fatalw("error creating role binding", "error", err)
 	}

--- a/internal/api/rolebindings.go
+++ b/internal/api/rolebindings.go
@@ -73,7 +73,7 @@ func (r *Router) roleBindingCreate(c echo.Context) error {
 		}
 	}
 
-	rb, err := r.engine.CreateRoleBinding(ctx, actor, resource, roleResource, subjects)
+	rb, err := r.engine.CreateRoleBinding(ctx, actor, resource, roleResource, body.Manager, subjects)
 	if err != nil {
 		return r.errorResponse("error creating role-binding", err)
 	}
@@ -83,6 +83,7 @@ func (r *Router) roleBindingCreate(c echo.Context) error {
 		roleBindingResponse{
 			ID:         rb.ID,
 			ResourceID: rb.ResourceID,
+			Manager:    rb.Manager,
 			SubjectIDs: rb.SubjectIDs,
 			RoleID:     rb.RoleID,
 
@@ -122,7 +123,16 @@ func (r *Router) roleBindingsList(c echo.Context) error {
 		return err
 	}
 
-	rbs, err := r.engine.ListRoleBindings(ctx, resource, nil)
+	var rbs []types.RoleBinding
+
+	params := c.QueryParams()
+
+	if params.Has("manager") {
+		rbs, err = r.engine.ListManagerRoleBindings(ctx, params.Get("manager"), resource, nil)
+	} else {
+		rbs, err = r.engine.ListRoleBindings(ctx, resource, nil)
+	}
+
 	if err != nil {
 		return r.errorResponse("error listing role-binding", err)
 	}
@@ -137,6 +147,7 @@ func (r *Router) roleBindingsList(c echo.Context) error {
 			ResourceID: rb.ResourceID,
 			SubjectIDs: rb.SubjectIDs,
 			RoleID:     rb.RoleID,
+			Manager:    rb.Manager,
 
 			CreatedBy: rb.CreatedBy,
 			UpdatedBy: rb.UpdatedBy,
@@ -242,6 +253,7 @@ func (r *Router) roleBindingGet(c echo.Context) error {
 			ResourceID: rb.ResourceID,
 			SubjectIDs: rb.SubjectIDs,
 			RoleID:     rb.RoleID,
+			Manager:    rb.Manager,
 
 			CreatedBy: rb.CreatedBy,
 			UpdatedBy: rb.UpdatedBy,
@@ -321,6 +333,7 @@ func (r *Router) roleBindingUpdate(c echo.Context) error {
 			ResourceID: rb.ResourceID,
 			SubjectIDs: rb.SubjectIDs,
 			RoleID:     rb.RoleID,
+			Manager:    rb.Manager,
 
 			CreatedBy: rb.CreatedBy,
 			UpdatedBy: rb.UpdatedBy,

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -6,6 +6,7 @@ import (
 
 type createRoleRequest struct {
 	Name    string   `json:"name" binding:"required"`
+	Manager string   `json:"manager"`
 	Actions []string `json:"actions" binding:"required"`
 }
 
@@ -17,6 +18,7 @@ type updateRoleRequest struct {
 type roleResponse struct {
 	ID      gidx.PrefixedID `json:"id"`
 	Name    string          `json:"name"`
+	Manager string          `json:"manager,omitempty"`
 	Actions []string        `json:"actions"`
 
 	ResourceID gidx.PrefixedID `json:"resource_id,omitempty"`
@@ -77,8 +79,9 @@ type listRolesV2Response struct {
 }
 
 type listRolesV2Role struct {
-	ID   gidx.PrefixedID `json:"id"`
-	Name string          `json:"name"`
+	ID      gidx.PrefixedID `json:"id"`
+	Name    string          `json:"name"`
+	Manager string          `json:"manager"`
 }
 
 // RoleBindings
@@ -86,6 +89,7 @@ type listRolesV2Role struct {
 type roleBindingRequest struct {
 	RoleID     string            `json:"role_id" binding:"required"`
 	SubjectIDs []gidx.PrefixedID `json:"subject_ids" binding:"required"`
+	Manager    string            `json:"manager"`
 }
 
 type rolebindingUpdateRequest struct {
@@ -96,6 +100,7 @@ type roleBindingResponse struct {
 	ID         gidx.PrefixedID   `json:"id"`
 	ResourceID gidx.PrefixedID   `json:"resource_id"`
 	RoleID     gidx.PrefixedID   `json:"role_id"`
+	Manager    string            `json:"manager"`
 	SubjectIDs []gidx.PrefixedID `json:"subject_ids"`
 
 	CreatedBy gidx.PrefixedID `json:"created_by"`

--- a/internal/query/example_policy_test.go
+++ b/internal/query/example_policy_test.go
@@ -179,13 +179,13 @@ func TestExamplePolicy(t *testing.T) {
 	require.NoError(t, err)
 
 	// create roles
-	superadmin, err := e.CreateRoleV2(ctx, superuser, tnnttenroot, "superuser", allactions)
+	superadmin, err := e.CreateRoleV2(ctx, superuser, tnnttenroot, t.Name(), "superuser", allactions)
 	require.NoError(t, err)
 
-	iamadmin, err := e.CreateRoleV2(ctx, superuser, tnnttena, "iam_admin", iamactions)
+	iamadmin, err := e.CreateRoleV2(ctx, superuser, tnnttena, t.Name(), "iam_admin", iamactions)
 	require.NoError(t, err)
 
-	lbadmin, err := e.CreateRoleV2(ctx, superuser, tnnttenroot, "lb_admin", lbactions)
+	lbadmin, err := e.CreateRoleV2(ctx, superuser, tnnttenroot, t.Name(), "lb_admin", lbactions)
 	require.NoError(t, err)
 
 	tc := []testingx.TestCase[any, any]{
@@ -193,7 +193,7 @@ func TestExamplePolicy(t *testing.T) {
 			Name: "superuser can do anything",
 			SetupFn: func(ctx context.Context, t *testing.T) context.Context {
 				role := types.Resource{Type: "role", ID: superadmin.ID}
-				_, err := e.CreateRoleBinding(ctx, superuser, tnnttenroot, role, []types.RoleBindingSubject{{SubjectResource: superuser}})
+				_, err := e.CreateRoleBinding(ctx, superuser, tnnttenroot, role, t.Name(), []types.RoleBindingSubject{{SubjectResource: superuser}})
 				require.NoError(t, err)
 
 				return ctx
@@ -229,7 +229,7 @@ func TestExamplePolicy(t *testing.T) {
 			Sync: true,
 			SetupFn: func(ctx context.Context, t *testing.T) context.Context {
 				role := types.Resource{Type: "role", ID: lbadmin.ID}
-				_, err := e.CreateRoleBinding(ctx, superuser, tnnttena, role, []types.RoleBindingSubject{{SubjectResource: groupadmin}})
+				_, err := e.CreateRoleBinding(ctx, superuser, tnnttena, role, t.Name(), []types.RoleBindingSubject{{SubjectResource: groupadmin}})
 				require.NoError(t, err)
 
 				return ctx
@@ -279,7 +279,7 @@ func TestExamplePolicy(t *testing.T) {
 			Sync: true,
 			SetupFn: func(ctx context.Context, t *testing.T) context.Context {
 				role := types.Resource{Type: "role", ID: iamadmin.ID}
-				_, err := e.CreateRoleBinding(ctx, superuser, tnnttena, role, []types.RoleBindingSubject{{SubjectResource: groupadminsubgroup}})
+				_, err := e.CreateRoleBinding(ctx, superuser, tnnttena, role, t.Name(), []types.RoleBindingSubject{{SubjectResource: groupadminsubgroup}})
 				require.NoError(t, err)
 
 				return ctx
@@ -326,7 +326,7 @@ func TestExamplePolicy(t *testing.T) {
 			Name: "iam-admin cannot be bind on tnntten-root",
 			CheckFn: func(ctx context.Context, t *testing.T, tr testingx.TestResult[any]) {
 				role := types.Resource{Type: "role", ID: iamadmin.ID}
-				_, err := e.CreateRoleBinding(ctx, superuser, tnnttenroot, role, []types.RoleBindingSubject{{SubjectResource: groupadminsubgroup}})
+				_, err := e.CreateRoleBinding(ctx, superuser, tnnttenroot, role, t.Name(), []types.RoleBindingSubject{{SubjectResource: groupadminsubgroup}})
 				assert.Error(t, err)
 				assert.ErrorIs(t, err, ErrRoleNotFound)
 			},

--- a/internal/query/mock/mock.go
+++ b/internal/query/mock/mock.go
@@ -50,7 +50,7 @@ func (e *Engine) CreateRelationships(context.Context, []types.Relationship) erro
 }
 
 // CreateRole creates a Role object and does not persist it anywhere.
-func (e *Engine) CreateRole(context.Context, types.Resource, types.Resource, string, []string) (types.Role, error) {
+func (e *Engine) CreateRole(context.Context, types.Resource, types.Resource, string, string, []string) (types.Role, error) {
 	args := e.Called()
 
 	retRole := args.Get(0).(types.Role)
@@ -60,12 +60,17 @@ func (e *Engine) CreateRole(context.Context, types.Resource, types.Resource, str
 
 // CreateRoleV2 creates a v2 role object
 // TODO: Implement this
-func (e *Engine) CreateRoleV2(context.Context, types.Resource, types.Resource, string, []string) (types.Role, error) {
+func (e *Engine) CreateRoleV2(context.Context, types.Resource, types.Resource, string, string, []string) (types.Role, error) {
 	return types.Role{}, nil
 }
 
 // ListRolesV2 list roles
 func (e *Engine) ListRolesV2(context.Context, types.Resource) ([]types.Role, error) {
+	return nil, nil
+}
+
+// ListManagerRolesV2 list roles
+func (e *Engine) ListManagerRolesV2(context.Context, string, types.Resource) ([]types.Role, error) {
 	return nil, nil
 }
 
@@ -127,6 +132,11 @@ func (e *Engine) ListRelationshipsTo(context.Context, types.Resource) ([]types.R
 
 // ListRoles returns nothing but satisfies the Engine interface.
 func (e *Engine) ListRoles(context.Context, types.Resource) ([]types.Role, error) {
+	return nil, nil
+}
+
+// ListManagerRoles returns nothing but satisfies the Engine interface.
+func (e *Engine) ListManagerRoles(context.Context, string, types.Resource) ([]types.Role, error) {
 	return nil, nil
 }
 
@@ -209,12 +219,17 @@ func (e *Engine) SubjectHasPermission(context.Context, types.Resource, string, t
 }
 
 // CreateRoleBinding returns nothing but satisfies the Engine interface.
-func (e *Engine) CreateRoleBinding(context.Context, types.Resource, types.Resource, types.Resource, []types.RoleBindingSubject) (types.RoleBinding, error) {
+func (e *Engine) CreateRoleBinding(context.Context, types.Resource, types.Resource, types.Resource, string, []types.RoleBindingSubject) (types.RoleBinding, error) {
 	return types.RoleBinding{}, nil
 }
 
 // ListRoleBindings returns nothing but satisfies the Engine interface.
 func (e *Engine) ListRoleBindings(context.Context, types.Resource, *types.Resource) ([]types.RoleBinding, error) {
+	return nil, nil
+}
+
+// ListManagerRoleBindings returns nothing but satisfies the Engine interface.
+func (e *Engine) ListManagerRoleBindings(context.Context, string, types.Resource, *types.Resource) ([]types.RoleBinding, error) {
 	return nil, nil
 }
 

--- a/internal/query/relations_test.go
+++ b/internal/query/relations_test.go
@@ -143,7 +143,7 @@ func TestCreateRoles(t *testing.T) {
 		actorRes, err := e.NewResourceFromID(gidx.MustNewID("idntusr"))
 		require.NoError(t, err)
 
-		role, err := e.CreateRole(ctx, actorRes, tenRes, "test", actions)
+		role, err := e.CreateRole(ctx, actorRes, tenRes, t.Name(), "test", actions)
 		if err != nil {
 			return testingx.TestResult[types.Role]{
 				Err: err,
@@ -175,7 +175,7 @@ func TestGetRoles(t *testing.T) {
 	actorRes, err := e.NewResourceFromID(gidx.MustNewID("idntusr"))
 	require.NoError(t, err)
 
-	role, err := e.CreateRole(ctx, actorRes, tenRes, "test", []string{"loadbalancer_get"})
+	role, err := e.CreateRole(ctx, actorRes, tenRes, t.Name(), "test", []string{"loadbalancer_get"})
 	require.NoError(t, err)
 	roleRes, err := e.NewResourceFromID(role.ID)
 	require.NoError(t, err)
@@ -233,7 +233,7 @@ func TestRoleUpdate(t *testing.T) {
 	actorUpdateRes, err := e.NewResourceFromID(gidx.MustNewID("idntusr"))
 	require.NoError(t, err)
 
-	role, err := e.CreateRole(ctx, actorRes, tenRes, "test", []string{"loadbalancer_get"})
+	role, err := e.CreateRole(ctx, actorRes, tenRes, t.Name(), "test", []string{"loadbalancer_get"})
 	require.NoError(t, err)
 	roles, err := e.ListRoles(ctx, tenRes)
 	require.NoError(t, err)
@@ -317,7 +317,7 @@ func TestListRoles(t *testing.T) {
 				tenRes, err := e.NewResourceFromID(tenID)
 				require.NoError(t, err)
 
-				role, err := e.CreateRole(ctx, actorRes, tenRes, t.Name(), []string{"loadbalancer_get"})
+				role, err := e.CreateRole(ctx, actorRes, tenRes, t.Name(), t.Name(), []string{"loadbalancer_get"})
 				require.NoError(t, err)
 				require.NotEmpty(t, role.ID)
 
@@ -342,7 +342,7 @@ func TestListRoles(t *testing.T) {
 				tenRes, err := e.NewResourceFromID(tenID)
 				require.NoError(t, err)
 
-				role, err := e.CreateRole(ctx, actorRes, tenRes, t.Name(), nil)
+				role, err := e.CreateRole(ctx, actorRes, tenRes, t.Name(), t.Name(), nil)
 				require.NoError(t, err)
 				require.NotEmpty(t, role.ID)
 
@@ -386,7 +386,7 @@ func TestRoleDelete(t *testing.T) {
 	actorRes, err := e.NewResourceFromID(gidx.MustNewID("idntusr"))
 	require.NoError(t, err)
 
-	role, err := e.CreateRole(ctx, actorRes, tenRes, "test", []string{"loadbalancer_get"})
+	role, err := e.CreateRole(ctx, actorRes, tenRes, t.Name(), "test", []string{"loadbalancer_get"})
 	require.NoError(t, err)
 	roles, err := e.ListRoles(ctx, tenRes)
 	require.NoError(t, err)
@@ -455,6 +455,7 @@ func TestAssignments(t *testing.T) {
 		ctx,
 		actorRes,
 		tenRes,
+		t.Name(),
 		"test",
 		[]string{
 			"loadbalancer_update",
@@ -515,6 +516,7 @@ func TestUnassignments(t *testing.T) {
 		ctx,
 		actorRes,
 		tenRes,
+		t.Name(),
 		"test",
 		[]string{
 			"loadbalancer_update",
@@ -768,6 +770,7 @@ func TestSubjectActions(t *testing.T) {
 		ctx,
 		actorRes,
 		tenRes,
+		t.Name(),
 		"test",
 		[]string{
 			"loadbalancer_update",

--- a/internal/query/rolebindings_test.go
+++ b/internal/query/rolebindings_test.go
@@ -47,7 +47,7 @@ func TestCreateRoleBinding(t *testing.T) {
 	actor, err := e.NewResourceFromIDString("idntusr-actor")
 	require.NoError(t, err)
 
-	role, err := e.CreateRoleV2(ctx, subj, root, "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
+	role, err := e.CreateRoleV2(ctx, subj, root, t.Name(), "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
 	require.NoError(t, err)
 
 	roleRes, err := e.NewResourceFromID(role.ID)
@@ -145,7 +145,7 @@ func TestCreateRoleBinding(t *testing.T) {
 	}
 
 	testFn := func(ctx context.Context, in input) testingx.TestResult[types.RoleBinding] {
-		rb, err := e.CreateRoleBinding(ctx, actor, in.resource, in.role, in.subjects)
+		rb, err := e.CreateRoleBinding(ctx, actor, in.resource, in.role, t.Name(), in.subjects)
 		return testingx.TestResult[types.RoleBinding]{Success: rb, Err: err}
 	}
 
@@ -166,10 +166,10 @@ func TestListRoleBindings(t *testing.T) {
 	actor, err := e.NewResourceFromIDString("idntusr-actor")
 	require.NoError(t, err)
 
-	viewer, err := e.CreateRoleV2(ctx, subj, root, "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
+	viewer, err := e.CreateRoleV2(ctx, subj, root, t.Name(), "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
 	require.NoError(t, err)
 
-	editor, err := e.CreateRoleV2(ctx, subj, root, "lb_editor", []string{"loadbalancer_list", "loadbalancer_get", "loadbalancer_create", "loadbalancer_update"})
+	editor, err := e.CreateRoleV2(ctx, subj, root, t.Name(), "lb_editor", []string{"loadbalancer_list", "loadbalancer_get", "loadbalancer_create", "loadbalancer_update"})
 	require.NoError(t, err)
 
 	viewerRes, err := e.NewResourceFromID(viewer.ID)
@@ -181,10 +181,10 @@ func TestListRoleBindings(t *testing.T) {
 	notfoundRole, err := e.NewResourceFromIDString("permrv2-notfound")
 	require.NoError(t, err)
 
-	_, err = e.CreateRoleBinding(ctx, actor, root, viewerRes, []types.RoleBindingSubject{{SubjectResource: subj}})
+	_, err = e.CreateRoleBinding(ctx, actor, root, viewerRes, t.Name(), []types.RoleBindingSubject{{SubjectResource: subj}})
 	require.NoError(t, err)
 
-	_, err = e.CreateRoleBinding(ctx, actor, root, editorRes, []types.RoleBindingSubject{{SubjectResource: subj}})
+	_, err = e.CreateRoleBinding(ctx, actor, root, editorRes, t.Name(), []types.RoleBindingSubject{{SubjectResource: subj}})
 	require.NoError(t, err)
 
 	_, err = e.client.WriteRelationships(ctx, &pb.WriteRelationshipsRequest{
@@ -270,7 +270,7 @@ func TestGetRoleBinding(t *testing.T) {
 	actor, err := e.NewResourceFromIDString("idntusr-actor")
 	require.NoError(t, err)
 
-	viewer, err := e.CreateRoleV2(ctx, subj, root, "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
+	viewer, err := e.CreateRoleV2(ctx, subj, root, t.Name(), "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
 	require.NoError(t, err)
 
 	viewerRes, err := e.NewResourceFromID(viewer.ID)
@@ -279,7 +279,7 @@ func TestGetRoleBinding(t *testing.T) {
 	notfoundRB, err := e.NewResourceFromIDString("permrbn-notfound")
 	require.NoError(t, err)
 
-	rb, err := e.CreateRoleBinding(ctx, actor, root, viewerRes, []types.RoleBindingSubject{{SubjectResource: subj}})
+	rb, err := e.CreateRoleBinding(ctx, actor, root, viewerRes, t.Name(), []types.RoleBindingSubject{{SubjectResource: subj}})
 	require.NoError(t, err)
 
 	rbRes, err := e.NewResourceFromID(rb.ID)
@@ -327,12 +327,12 @@ func TestUpdateRoleBinding(t *testing.T) {
 	actor, err := e.NewResourceFromIDString("idntusr-actor")
 	require.NoError(t, err)
 
-	viewer, err := e.CreateRoleV2(ctx, subj, root, "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
+	viewer, err := e.CreateRoleV2(ctx, subj, root, t.Name(), "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
 	require.NoError(t, err)
 	viewerRes, err := e.NewResourceFromID(viewer.ID)
 	require.NoError(t, err)
 
-	rb, err := e.CreateRoleBinding(ctx, subj, root, viewerRes, []types.RoleBindingSubject{{SubjectResource: subj}})
+	rb, err := e.CreateRoleBinding(ctx, subj, root, viewerRes, t.Name(), []types.RoleBindingSubject{{SubjectResource: subj}})
 	require.NoError(t, err)
 	rbRes, err := e.NewResourceFromID(rb.ID)
 	require.NoError(t, err)
@@ -425,12 +425,12 @@ func TestDeleteRoleBinding(t *testing.T) {
 	actor, err := e.NewResourceFromIDString("idntusr-actor")
 	require.NoError(t, err)
 
-	viewer, err := e.CreateRoleV2(ctx, actor, root, "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
+	viewer, err := e.CreateRoleV2(ctx, actor, root, t.Name(), "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
 	require.NoError(t, err)
 	viewerRes, err := e.NewResourceFromID(viewer.ID)
 	require.NoError(t, err)
 
-	rb, err := e.CreateRoleBinding(ctx, actor, root, viewerRes, []types.RoleBindingSubject{{SubjectResource: actor}})
+	rb, err := e.CreateRoleBinding(ctx, actor, root, viewerRes, t.Name(), []types.RoleBindingSubject{{SubjectResource: actor}})
 	require.NoError(t, err)
 	rbRes, err := e.NewResourceFromID(rb.ID)
 	require.NoError(t, err)
@@ -492,7 +492,7 @@ func TestPermissions(t *testing.T) {
 	require.NoError(t, err)
 
 	// role
-	viewer, err := e.CreateRoleV2(ctx, actor, root, "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
+	viewer, err := e.CreateRoleV2(ctx, actor, root, t.Name(), "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
 	require.NoError(t, err)
 	viewerRes, err := e.NewResourceFromID(viewer.ID)
 	require.NoError(t, err)
@@ -545,7 +545,7 @@ func TestPermissions(t *testing.T) {
 				})
 				require.Error(t, err)
 
-				_, err = e.CreateRoleBinding(ctx, user1, lb1, viewerRes, []types.RoleBindingSubject{{SubjectResource: user1}})
+				_, err = e.CreateRoleBinding(ctx, user1, lb1, viewerRes, t.Name(), []types.RoleBindingSubject{{SubjectResource: user1}})
 				require.NoError(t, err)
 
 				return ctx
@@ -579,7 +579,7 @@ func TestPermissions(t *testing.T) {
 				})
 				require.Error(t, err)
 
-				_, err = e.CreateRoleBinding(ctx, user1, child, viewerRes, []types.RoleBindingSubject{{SubjectResource: user1}})
+				_, err = e.CreateRoleBinding(ctx, user1, child, viewerRes, t.Name(), []types.RoleBindingSubject{{SubjectResource: user1}})
 				require.NoError(t, err)
 
 				return ctx
@@ -613,7 +613,7 @@ func TestPermissions(t *testing.T) {
 				})
 				require.Error(t, err)
 
-				_, err = e.CreateRoleBinding(ctx, user1, root, viewerRes, []types.RoleBindingSubject{{SubjectResource: user1}})
+				_, err = e.CreateRoleBinding(ctx, user1, root, viewerRes, t.Name(), []types.RoleBindingSubject{{SubjectResource: user1}})
 				require.NoError(t, err)
 
 				return ctx
@@ -647,7 +647,7 @@ func TestPermissions(t *testing.T) {
 				})
 				require.Error(t, err)
 
-				rb, err = e.CreateRoleBinding(ctx, user1, root, viewerRes, []types.RoleBindingSubject{{SubjectResource: group1}})
+				rb, err = e.CreateRoleBinding(ctx, user1, root, viewerRes, t.Name(), []types.RoleBindingSubject{{SubjectResource: group1}})
 				require.NoError(t, err)
 
 				return ctx

--- a/internal/query/roles_v2_test.go
+++ b/internal/query/roles_v2_test.go
@@ -130,7 +130,7 @@ func TestCreateRolesV2(t *testing.T) {
 	}
 
 	testFn := func(ctx context.Context, in input) testingx.TestResult[types.Role] {
-		r, err := e.CreateRoleV2(ctx, actor, in.owner, in.name, in.actions)
+		r, err := e.CreateRoleV2(ctx, actor, in.owner, t.Name(), in.name, in.actions)
 		if err != nil {
 			return testingx.TestResult[types.Role]{Err: err}
 		}
@@ -158,7 +158,7 @@ func TestGetRoleV2(t *testing.T) {
 	actor, err := e.NewResourceFromIDString("idntusr-actor")
 	require.NoError(t, err)
 
-	role, err := e.CreateRoleV2(ctx, actor, tenant, "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
+	role, err := e.CreateRoleV2(ctx, actor, tenant, t.Name(), "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
 	require.NoError(t, err)
 
 	roleRes, err := e.NewResourceFromID(role.ID)
@@ -231,13 +231,13 @@ func TestListRolesV2(t *testing.T) {
 	actor, err := e.NewResourceFromIDString("idntusr-actor")
 	require.NoError(t, err)
 
-	_, err = e.CreateRoleV2(ctx, actor, root, "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
+	_, err = e.CreateRoleV2(ctx, actor, root, t.Name(), "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
 	require.NoError(t, err)
 
-	_, err = e.CreateRoleV2(ctx, actor, root, "lb_editor", []string{"loadbalancer_list", "loadbalancer_get", "loadbalancer_update"})
+	_, err = e.CreateRoleV2(ctx, actor, root, t.Name(), "lb_editor", []string{"loadbalancer_list", "loadbalancer_get", "loadbalancer_update"})
 	require.NoError(t, err)
 
-	_, err = e.CreateRoleV2(ctx, actor, child, "custom_role", []string{"loadbalancer_list"})
+	_, err = e.CreateRoleV2(ctx, actor, child, t.Name(), "custom_role", []string{"loadbalancer_list"})
 	require.NoError(t, err)
 
 	invalidOwner, err := e.NewResourceFromIDString("idntgrp-group")
@@ -299,7 +299,7 @@ func TestUpdateRolesV2(t *testing.T) {
 	actor, err := e.NewResourceFromIDString("idntusr-actor")
 	require.NoError(t, err)
 
-	role, err := e.CreateRoleV2(ctx, actor, tenant, "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
+	role, err := e.CreateRoleV2(ctx, actor, tenant, t.Name(), "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
 	require.NoError(t, err)
 
 	roleRes, err := e.NewResourceFromID(role.ID)
@@ -413,7 +413,7 @@ func TestDeleteRolesV2(t *testing.T) {
 	actor, err := e.NewResourceFromIDString("idntusr-actor")
 	require.NoError(t, err)
 
-	role, err := e.CreateRoleV2(ctx, subj, root, "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
+	role, err := e.CreateRoleV2(ctx, subj, root, t.Name(), "lb_viewer", []string{"loadbalancer_list", "loadbalancer_get"})
 	require.NoError(t, err)
 
 	roleRes, err := e.NewResourceFromID(role.ID)
@@ -433,13 +433,13 @@ func TestDeleteRolesV2(t *testing.T) {
 	require.NoError(t, err)
 
 	// these bindings are expected to be deleted after the role is deleted
-	rbRoot, err := e.CreateRoleBinding(ctx, actor, root, roleRes, []types.RoleBindingSubject{{SubjectResource: subj}})
+	rbRoot, err := e.CreateRoleBinding(ctx, actor, root, roleRes, t.Name(), []types.RoleBindingSubject{{SubjectResource: subj}})
 	require.NoError(t, err)
 
-	rbChild, err := e.CreateRoleBinding(ctx, actor, child, roleRes, []types.RoleBindingSubject{{SubjectResource: subj}})
+	rbChild, err := e.CreateRoleBinding(ctx, actor, child, roleRes, t.Name(), []types.RoleBindingSubject{{SubjectResource: subj}})
 	require.NoError(t, err)
 
-	rbTheOtherChild, err := e.CreateRoleBinding(ctx, actor, theotherchild, roleRes, []types.RoleBindingSubject{{SubjectResource: subj}})
+	rbTheOtherChild, err := e.CreateRoleBinding(ctx, actor, theotherchild, roleRes, t.Name(), []types.RoleBindingSubject{{SubjectResource: subj}})
 	require.NoError(t, err)
 
 	rb, err := e.ListRoleBindings(ctx, root, &roleRes)

--- a/internal/query/service.go
+++ b/internal/query/service.go
@@ -29,7 +29,7 @@ type Engine interface {
 	AssignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) error
 	UnassignSubjectRole(ctx context.Context, subject types.Resource, role types.Role) error
 	CreateRelationships(ctx context.Context, rels []types.Relationship) error
-	CreateRole(ctx context.Context, actor, res types.Resource, roleName string, actions []string) (types.Role, error)
+	CreateRole(ctx context.Context, actor, res types.Resource, manager, roleName string, actions []string) (types.Role, error)
 	UpdateRole(ctx context.Context, actor, roleResource types.Resource, newName string, newActions []string) (types.Role, error)
 	GetRole(ctx context.Context, roleResource types.Resource) (types.Role, error)
 	GetRoleResource(ctx context.Context, roleResource types.Resource) (types.Resource, error)
@@ -37,6 +37,7 @@ type Engine interface {
 	ListRelationshipsFrom(ctx context.Context, resource types.Resource) ([]types.Relationship, error)
 	ListRelationshipsTo(ctx context.Context, resource types.Resource) ([]types.Relationship, error)
 	ListRoles(ctx context.Context, resource types.Resource) ([]types.Role, error)
+	ListManagerRoles(ctx context.Context, manager string, resource types.Resource) ([]types.Role, error)
 	DeleteRelationships(ctx context.Context, relationships ...types.Relationship) error
 	DeleteRole(ctx context.Context, roleResource types.Resource) error
 	DeleteResourceRelationships(ctx context.Context, resource types.Resource) error
@@ -47,9 +48,11 @@ type Engine interface {
 	// v2 functions, add role bindings support
 
 	// CreateRoleV2 creates a v2 role scoped to the given owner resource with the given actions.
-	CreateRoleV2(ctx context.Context, actor, owner types.Resource, roleName string, actions []string) (types.Role, error)
+	CreateRoleV2(ctx context.Context, actor, owner types.Resource, manager, roleName string, actions []string) (types.Role, error)
 	// ListRolesV2 returns all V2 roles owned by the given resource.
 	ListRolesV2(ctx context.Context, owner types.Resource) ([]types.Role, error)
+	// ListManagerRolesV2 returns all V2 roles owned by the given resource with the given manager.
+	ListManagerRolesV2(ctx context.Context, manager string, owner types.Resource) ([]types.Role, error)
 	// GetRoleV2 returns a V2 role
 	GetRoleV2(ctx context.Context, role types.Resource) (types.Role, error)
 	// UpdateRoleV2 updates a V2 role with the given name and actions.
@@ -60,10 +63,13 @@ type Engine interface {
 	// CreateRoleBinding creates all the necessary relationships for a role binding.
 	// role binding here establishes a three-way relationship between a role,
 	// a resource, and the subjects.
-	CreateRoleBinding(ctx context.Context, actor, resource, role types.Resource, subjects []types.RoleBindingSubject) (types.RoleBinding, error)
+	CreateRoleBinding(ctx context.Context, actor, resource, role types.Resource, manager string, subjects []types.RoleBindingSubject) (types.RoleBinding, error)
 	// ListRoleBindings lists all role-bindings for a resource, an optional Role
 	// can be provided to filter the role-bindings.
 	ListRoleBindings(ctx context.Context, resource types.Resource, optionalRole *types.Resource) ([]types.RoleBinding, error)
+	// ListManagerRoleBindings lists all role-bindings for a resource with the given manager,
+	// an optional Role can be provided to filter the role-bindings.
+	ListManagerRoleBindings(ctx context.Context, manager string, resource types.Resource, optionalRole *types.Resource) ([]types.RoleBinding, error)
 	// GetRoleBinding fetches a role-binding by its ID.
 	GetRoleBinding(ctx context.Context, rolebinding types.Resource) (types.RoleBinding, error)
 	// UpdateRoleBinding updates the subjects of a role-binding.

--- a/internal/storage/migrations/20241001000000_manager_fields.sql
+++ b/internal/storage/migrations/20241001000000_manager_fields.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+
+ALTER TABLE roles ADD COLUMN IF NOT EXISTS manager CHARACTER VARYING(128) NOT NULL DEFAULT '';
+ALTER TABLE rolebindings ADD COLUMN IF NOT EXISTS manager CHARACTER VARYING(128) NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS "roles_manager_resource_id" ON "roles" ("manager", "resource_id");
+CREATE INDEX IF NOT EXISTS "rolebindings_manager_resource_id" ON "rolebindings" ("manager", "resource_id");

--- a/internal/storage/rolebinding_test.go
+++ b/internal/storage/rolebinding_test.go
@@ -26,7 +26,7 @@ func TestGetRoleBindingByID(t *testing.T) {
 	dbCtx, err := store.BeginContext(ctx)
 	require.NoError(t, err, "no error expected beginning transaction context")
 
-	rb, err := store.CreateRoleBinding(dbCtx, actorID, rbID, resourceID)
+	rb, err := store.CreateRoleBinding(dbCtx, actorID, rbID, resourceID, t.Name())
 	require.NoError(t, err, "no error expected creating role binding")
 
 	err = store.CommitContext(dbCtx)
@@ -85,7 +85,7 @@ func TestListResourceRoleBindings(t *testing.T) {
 	require.NoError(t, err, "no error expected beginning transaction context")
 
 	for _, rbID := range rbIDs {
-		rbs[rbID], err = store.CreateRoleBinding(dbCtx, actorID, rbID, resourceID)
+		rbs[rbID], err = store.CreateRoleBinding(dbCtx, actorID, rbID, resourceID, t.Name())
 		require.NoError(t, err, "no error expected creating role binding")
 	}
 
@@ -173,7 +173,7 @@ func TestCreateRoleBinding(t *testing.T) {
 			return result
 		}
 
-		result.Success, result.Err = store.CreateRoleBinding(dbCtx, actorID, input, resourceID)
+		result.Success, result.Err = store.CreateRoleBinding(dbCtx, actorID, input, resourceID, t.Name())
 		if result.Err != nil {
 			store.RollbackContext(dbCtx) //nolint:errcheck // skip check in test
 
@@ -201,7 +201,7 @@ func TestUpdateRoleBinding(t *testing.T) {
 	dbCtx, err := store.BeginContext(ctx)
 	require.NoError(t, err, "no error expected beginning transaction context")
 
-	_, err = store.CreateRoleBinding(dbCtx, actorID, rbID, resourceID)
+	_, err = store.CreateRoleBinding(dbCtx, actorID, rbID, resourceID, t.Name())
 	require.NoError(t, err, "no error expected creating role binding")
 
 	err = store.CommitContext(dbCtx)
@@ -267,7 +267,7 @@ func TestDeleteRoleBinding(t *testing.T) {
 	dbCtx, err := store.BeginContext(ctx)
 	require.NoError(t, err, "no error expected beginning transaction context")
 
-	_, err = store.CreateRoleBinding(dbCtx, actorID, rbID, resourceID)
+	_, err = store.CreateRoleBinding(dbCtx, actorID, rbID, resourceID, t.Name())
 	require.NoError(t, err, "no error expected creating role binding")
 
 	err = store.CommitContext(dbCtx)

--- a/internal/storage/roles_test.go
+++ b/internal/storage/roles_test.go
@@ -29,7 +29,7 @@ func TestGetRoleByID(t *testing.T) {
 	dbCtx, err := store.BeginContext(ctx)
 	require.NoError(t, err, "no error expected beginning transaction context")
 
-	createdRole, err := store.CreateRole(dbCtx, actorID, roleID, roleName, resourceID)
+	createdRole, err := store.CreateRole(dbCtx, actorID, roleID, roleName, t.Name(), resourceID)
 	require.NoError(t, err, "no error expected while seeding database role")
 
 	err = store.CommitContext(dbCtx)
@@ -93,7 +93,7 @@ func TestListResourceRoles(t *testing.T) {
 	require.NoError(t, err, "no error expected beginning transaction context")
 
 	for roleName, roleID := range groups {
-		_, err := store.CreateRole(dbCtx, actorID, roleID, roleName, resourceID)
+		_, err := store.CreateRole(dbCtx, actorID, roleID, roleName, t.Name(), resourceID)
 
 		require.NoError(t, err, "no error expected creating role", roleName)
 	}
@@ -216,7 +216,7 @@ func TestCreateRole(t *testing.T) {
 			return result
 		}
 
-		result.Success, result.Err = store.CreateRole(dbCtx, actorID, input.id, input.name, resourceID)
+		result.Success, result.Err = store.CreateRole(dbCtx, actorID, input.id, input.name, t.Name(), resourceID)
 		if result.Err != nil {
 			store.RollbackContext(dbCtx) //nolint:errcheck // skip check in test
 
@@ -251,10 +251,10 @@ func TestUpdateRole(t *testing.T) {
 
 	require.NoError(t, err, "no error expected beginning transaction context")
 
-	createdDBRole1, err := store.CreateRole(dbCtx, actorID, role1ID, role1Name, resourceID)
+	createdDBRole1, err := store.CreateRole(dbCtx, actorID, role1ID, role1Name, t.Name(), resourceID)
 	require.NoError(t, err, "no error expected while seeding database role")
 
-	_, err = store.CreateRole(dbCtx, actorID, role2ID, role2Name, resourceID)
+	_, err = store.CreateRole(dbCtx, actorID, role2ID, role2Name, t.Name(), resourceID)
 	require.NoError(t, err, "no error expected while seeding database role 2")
 
 	err = store.CommitContext(dbCtx)
@@ -361,7 +361,7 @@ func TestDeleteRole(t *testing.T) {
 
 	require.NoError(t, err, "no error expected beginning transaction context")
 
-	createdDBRole, err := store.CreateRole(dbCtx, actorID, roleID, roleName, resourceID)
+	createdDBRole, err := store.CreateRole(dbCtx, actorID, roleID, roleName, t.Name(), resourceID)
 
 	require.NoError(t, err, "no error expected while seeding database role")
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -11,6 +11,7 @@ import (
 type Role struct {
 	ID      gidx.PrefixedID
 	Name    string
+	Manager string
 	Actions []string
 
 	ResourceID gidx.PrefixedID
@@ -97,6 +98,7 @@ type Relationship struct {
 type RoleBinding struct {
 	ID         gidx.PrefixedID
 	ResourceID gidx.PrefixedID
+	Manager    string
 	RoleID     gidx.PrefixedID
 	SubjectIDs []gidx.PrefixedID
 

--- a/openapi-v2.yaml
+++ b/openapi-v2.yaml
@@ -20,6 +20,8 @@ paths:
         list all available roles for a resource, including roles that are
         inherited from parent resources
       operationId: listRoles
+      parameters:
+        - $ref: '#/components/parameters/manager'
       responses:
         "200":
           description: tnntten-root
@@ -72,6 +74,9 @@ paths:
                         name:
                           type: string
                           example: super_user
+                        manager:
+                          type: string
+                          example: service-a
                         updated_at:
                           type: string
                           example: "2024-04-10T20:18:10Z"
@@ -166,6 +171,9 @@ paths:
                 name:
                   type: string
                   example: lb_editor
+                manager:
+                  type: string
+                  example: service-a
             examples:
               create-role:
                 value:
@@ -175,6 +183,7 @@ paths:
                     - loadbalancer_update
                     - loadbalancer_create
                   name: lb_editor
+                  manager: svc-access-manager
       responses:
         "201":
           description: "role object"
@@ -214,6 +223,9 @@ paths:
                   name:
                     type: string
                     example: super_admin
+                  manager:
+                    type: string
+                    example: svc-access-manager
                   resource_id:
                     type: string
                     example: tnntten-root
@@ -235,52 +247,46 @@ paths:
                     created_by: idntusr-bailin
                     id: permrv2-IG7RfsYhyga0EwEbY4BKs
                     name: lb_editor
+                    manager: svc-access-manager
                     resource_id: tnntten-a
                     updated_at: "2024-02-29T18:18:18Z"
                     updated_by: idntusr-bailin
-                lb-viwer:
+                lb-viewer:
                   value:
                     actions:
-                      - role_list
-                      - rolebinding_create
                       - loadbalancer_list
-                      - loadbalancer_update
-                      - loadbalancer_delete
-                      - role_create
-                      - role_delete
-                      - loadbalancer_create
                       - loadbalancer_get
-                      - rolebinding_list
-                      - rolebinding_delete
-                      - role_get
-                      - role_update
                     created_at: "2024-02-28T17:22:04Z"
                     created_by: idntusr-bailin
-                    id: permrv2-ecBlNMsPrvVFgUUAUfmeY
-                    name: super_admin
+                    id: permrv2-ecBlNMsYhyga0EwEUffsY
+                    name: lb_viewer
+                    manager: svc-access-manager
                     resource_id: tnntten-root
                     updated_at: "2024-02-28T17:22:04Z"
                     updated_by: idntusr-bailin
                 super-admin:
                   value:
                     actions:
-                      - role_list
-                      - rolebinding_create
+                      - loadbalancer_create
+                      - loadbalancer_delete
+                      - loadbalancer_get
                       - loadbalancer_list
                       - loadbalancer_update
-                      - loadbalancer_delete
                       - role_create
                       - role_delete
-                      - loadbalancer_create
-                      - loadbalancer_get
-                      - rolebinding_list
-                      - rolebinding_delete
                       - role_get
+                      - role_list
                       - role_update
+                      - iam_rolebinding_create
+                      - iam_rolebinding_delete
+                      - iam_rolebinding_get
+                      - iam_rolebinding_list
+                      - iam_rolebinding_update
                     created_at: "2024-02-28T17:22:04Z"
                     created_by: idntusr-bailin
                     id: permrv2-ecBlNMsPrvVFgUUAUfmeY
                     name: super_admin
+                    manager: svc-access-manager
                     resource_id: tnntten-root
                     updated_at: "2024-02-28T17:22:04Z"
                     updated_by: idntusr-bailin
@@ -396,6 +402,9 @@ paths:
                   name:
                     type: string
                     example: super_user
+                  manager:
+                    type: string
+                    example: service-a
                   resource_id:
                     type: string
                     example: tnntten-root
@@ -699,6 +708,7 @@ paths:
         an optional query parameter `role_id` can be used to filter the results.
       operationId: listRoleBindings
       parameters:
+        - $ref: '#/components/parameters/manager'
         - name: role_id
           in: query
           schema:
@@ -826,6 +836,9 @@ paths:
             schema:
               type: object
               properties:
+                manager:
+                  type: string
+                  example: service-a
                 role_id:
                   type: string
                   example: permrv2-PLjILDwe8kG_t42tMCDiB
@@ -840,6 +853,7 @@ paths:
               create-role-binding:
                 value:
                   role_id: permrv2-PLjILDwe8kG_t42tMCDiB
+                  manager: svc-access-manager
                   subject_ids:
                     - idntgrp-my-subgroup
       responses:
@@ -1154,7 +1168,15 @@ paths:
                     - iam_rolebinding_create
                     - iam_rolebinding_update
                     - iam_rolebinding_delete
+
 components:
+  parameters:
+    manager:
+      in: query
+      name: manager
+      required: false
+      schema:
+        type: string
   securitySchemes:
     oauth2:
       type: oauth2


### PR DESCRIPTION
This adds a manager field to roles and role bindings allowing services to mark the manager of a specific role / role binding.

This allows the managing service to easily filter out unmanaged roles / role bindings which it does not own which allows for cleaner logic for reconciling roles/role bindings.

Both roles and role binding create requests can provide an optional `manager` field and role / role binding list endpoints can now be provided an optional `manager` query value.